### PR TITLE
#249 Implemented deterministic random execution order

### DIFF
--- a/main.py
+++ b/main.py
@@ -354,9 +354,7 @@ def _assert_related_ids_resolvable(
             missing[experiment_id] = unresolved
 
     if missing:
-        raise ValueError(
-            f"Unresolvable related_script_ids references: {missing}"
-        )
+        raise ValueError(f"Unresolvable related_script_ids references: {missing}")
 
 
 def _get_experiment_from_id(

--- a/main.py
+++ b/main.py
@@ -39,10 +39,18 @@ def _run_benchmarks(
 ) -> None:
     logger.info(f"Executing benchmark run {benchmark_run}/{Config.BENCHMARK_RUNS}.")
 
-    experiments = benchmark_configuration["experiments"]
+    experiments = list(benchmark_configuration["experiments"])
 
-    if Config.IS_REVERSED_BENCHMARK_EXECTUION_ORDER:
-        experiments.reverse()
+    rng = random.Random(benchmark_run)
+    rng.shuffle(experiments)
+
+    _assert_related_ids_resolvable(experiments)
+
+    logger.info(
+        "Benchmark run %s execution order: %s",
+        benchmark_run,
+        [exp["id"] for exp in experiments],
+    )
 
     completed_experiments: list[str] = []
     _clear_all_container_instances(experiments)
@@ -328,6 +336,27 @@ def _check_container_state(
             case _:
                 lines_seen = _stream_container_logs(container_group_name, lines_seen)
                 time.sleep(poll_interval_seconds)
+
+
+def _assert_related_ids_resolvable(
+    experiments: list[dict[str, str | int | list[str]]],
+) -> None:
+    known_ids = {str(exp["id"]) for exp in experiments}
+    missing: dict[str, list[str]] = {}
+
+    for experiment in experiments:
+        experiment_id = str(experiment["id"])
+        related_ids = experiment.get("related_script_ids") or []
+        unresolved = [
+            str(rid) for rid in related_ids if str(rid) not in known_ids  # type: ignore
+        ]
+        if unresolved:
+            missing[experiment_id] = unresolved
+
+    if missing:
+        raise ValueError(
+            f"Unresolvable related_script_ids references: {missing}"
+        )
 
 
 def _get_experiment_from_id(

--- a/src/config.py
+++ b/src/config.py
@@ -13,7 +13,6 @@ load_dotenv(find_dotenv())
 class Config:
     IS_NOTEBOOK: bool = False
     IOU_ROUNDING_DECIMALS: int = 9
-    IS_REVERSED_BENCHMARK_EXECTUION_ORDER: bool = False
 
     # AZURE
     AZURE_RESOURCE_GROUP: str = "doppa"


### PR DESCRIPTION
This pull request updates the benchmark execution logic to randomize experiment order per run and adds validation to ensure all related experiment IDs are resolvable. It also removes the unused configuration option for reversing the benchmark order.

**Benchmark execution order and validation:**

* Benchmark experiments are now shuffled in a deterministic way per run using a seeded random number generator, replacing the previous (now removed) option to reverse execution order. This ensures varied execution sequences across runs while preserving reproducibility. (`main.py`, `src/config.py`) [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L42-R53) [[2]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L16)
* Introduced the `_assert_related_ids_resolvable` function to check that all `related_script_ids` referenced by experiments exist in the current set, raising a clear error if any are missing. (`main.py`) [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R341-R361) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L42-R53)

**Configuration cleanup:**

* Removed the obsolete `IS_REVERSED_BENCHMARK_EXECTUION_ORDER` setting from the `Config` class, since experiment order is now always randomized. (`src/config.py`)