### PR TITLE
Feature/247 widen per iteration sample schema and force result materialization

### DIFF
--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -6,13 +6,13 @@ from src.application.common import logger
 from src.application.common.monitor_utils import (
     _get_run_id,
     _get_benchmark_run,
-    _measure_net_io,
+    _measure_io,
     _save_run,
     _save_run_metadata,
     _save_run_cost_analytics,
 )
 from src.application.dtos import CostConfiguration
-from src.domain.enums import BenchmarkIteration, BlobOperationType
+from src.domain.enums import BenchmarkIteration, BlobOperationType, SchemaVersion
 
 
 def monitor(
@@ -29,7 +29,7 @@ def monitor(
     :param benchmark_iteration: Number of timed iterations to run.
     :param cost_configuration: Which Azure cost components to compute and store.
     :param skip_warmup: Disable warmup runs. Use for Databricks, since each run provisions a cluster and warmup would multiply cost. Default is False.
-    :param elapsed_from_result: Treat the wrapped function's return value as the elapsed time in seconds instead of wall-clock. Use for Databricks, since the API-reported notebook execution time excludes cluster provisioning/teardown. Default is False.
+    :param elapsed_from_result: Treat the wrapped function's return value as a (elapsed_seconds, cardinality) tuple instead of using wall-clock time and len(result). Use for Databricks, since the notebook self-reports both. Default is False.
     """
 
     def decorator(func):
@@ -64,10 +64,23 @@ def monitor(
 
             for i in range(benchmark_iteration.value):
                 iteration = i + 1
-                result, wall_elapsed_time, net_bytes_sent, net_bytes_received = (
-                    _measure_net_io(func, *args, **kwargs)
-                )
-                elapsed_time = result if elapsed_from_result else wall_elapsed_time
+
+                started_at = datetime.datetime.now(datetime.UTC)
+                (
+                    result,
+                    wall_elapsed_time,
+                    net_bytes_sent,
+                    net_bytes_received,
+                    cpu_time_user_seconds,
+                    cpu_time_system_seconds,
+                ) = _measure_io(func, *args, **kwargs)
+                ended_at = datetime.datetime.now(datetime.UTC)
+
+                if elapsed_from_result:
+                    elapsed_time, result_cardinality = result
+                else:
+                    elapsed_time = wall_elapsed_time
+                    result_cardinality = len(result) if result is not None else -1
 
                 ingress_sum += net_bytes_received
                 egress_sum += net_bytes_sent
@@ -83,6 +96,12 @@ def monitor(
                             "elapsed_time": elapsed_time,
                             "network_bytes_sent": net_bytes_sent,
                             "network_bytes_received": net_bytes_received,
+                            "started_at": started_at.isoformat(),
+                            "ended_at": ended_at.isoformat(),
+                            "cpu_time_user_seconds": cpu_time_user_seconds,
+                            "cpu_time_system_seconds": cpu_time_system_seconds,
+                            "result_cardinality": result_cardinality,
+                            "schema_version": SchemaVersion.V2.value,
                         }
                     ],
                 )

--- a/src/application/common/monitor_utils.py
+++ b/src/application/common/monitor_utils.py
@@ -165,17 +165,29 @@ def _create_global_iteration(
     return iteration + total_iterations * (benchmark_run - 1)
 
 
-def _measure_net_io(func, *args, **kwargs) -> tuple[Any, float, int, int]:
-    before = psutil.net_io_counters()
+def _measure_io(func, *args, **kwargs) -> tuple[Any, float, int, int, float, float]:
+    process = psutil.Process()
+    net_before = psutil.net_io_counters()
+    cpu_before = process.cpu_times()
     start_time = time.perf_counter()
 
     result = func(*args, **kwargs)
 
     end_time = time.perf_counter()
-    after = psutil.net_io_counters()
+    cpu_after = process.cpu_times()
+    net_after = psutil.net_io_counters()
 
     elapsed_time = end_time - start_time
-    network_bytes_sent = after.bytes_sent - before.bytes_sent
-    network_bytes_received = after.bytes_recv - before.bytes_recv
+    network_bytes_sent = net_after.bytes_sent - net_before.bytes_sent
+    network_bytes_received = net_after.bytes_recv - net_before.bytes_recv
+    cpu_time_user_seconds = cpu_after.user - cpu_before.user
+    cpu_time_system_seconds = cpu_after.system - cpu_before.system
 
-    return result, elapsed_time, network_bytes_sent, network_bytes_received
+    return (
+        result,
+        elapsed_time,
+        network_bytes_sent,
+        network_bytes_received,
+        cpu_time_user_seconds,
+        cpu_time_system_seconds,
+    )

--- a/src/application/contracts/databricks_service_interface.py
+++ b/src/application/contracts/databricks_service_interface.py
@@ -3,12 +3,13 @@ from abc import ABC, abstractmethod
 
 class IDatabricksService(ABC):
     @abstractmethod
-    def submit_and_wait(self, num_workers: int) -> float:
+    def submit_and_wait(self, num_workers: int) -> tuple[float, int]:
         """
         Submit a one-time Databricks run for the national-scale spatial join and block until it reaches
         a terminal state (TERMINATED, SKIPPED, or INTERNAL_ERROR).
         :param num_workers: Number of worker nodes to provision for the cluster.
-        :return: Notebook execution duration in seconds (excludes cluster provisioning and teardown).
-        :raises RuntimeError: If the run finishes in a non-successful state.
+        :return: Tuple of (elapsed_seconds, cardinality) self-reported by the notebook via dbutils.notebookExit JSON.
+            elapsed_seconds measures the spatial join + count() only (excludes cluster provisioning, Sedona init, and teardown).
+        :raises RuntimeError: If the run finishes in a non-successful state or the notebook does not emit the expected JSON payload.
         """
         raise NotImplementedError

--- a/src/domain/enums/__init__.py
+++ b/src/domain/enums/__init__.py
@@ -7,3 +7,4 @@ from .epsg_code import EPSGCode
 from .theme import Theme
 from .data_source import DataSource
 from .bounding_box import BoundingBox
+from .schema_version import SchemaVersion

--- a/src/domain/enums/schema_version.py
+++ b/src/domain/enums/schema_version.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class SchemaVersion(Enum):
+    V2 = "v2"

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import time
 from pathlib import Path
 
@@ -34,13 +35,14 @@ class DatabricksService(IDatabricksService):
             "Content-Type": "application/json",
         }
 
-    def submit_and_wait(self, num_workers: int) -> float:
+    def submit_and_wait(self, num_workers: int) -> tuple[float, int]:
         self._upload_notebook()
         run_id = self._submit_run(num_workers)
         logger.info(
             f"Submitted Databricks run {run_id} with {num_workers} worker(s). Polling for completion."
         )
-        return self._wait_for_run(run_id)
+        self._wait_for_run(run_id)
+        return self._fetch_notebook_output(run_id)
 
     def _upload_notebook(self) -> None:
         folder = str(Path(Config.DATABRICKS_WORKSPACE_NOTEBOOK_PATH).parent)
@@ -128,8 +130,8 @@ class DatabricksService(IDatabricksService):
         run_id: str = str(response.json()["run_id"])
         return run_id
 
-    def _wait_for_run(self, run_id: str) -> float:
-        """Poll until terminal state. Returns execution_duration in seconds (excludes provisioning)."""
+    def _wait_for_run(self, run_id: str) -> None:
+        """Poll until terminal state. Logs API-reported durations for diagnostic purposes."""
         while True:
             response = requests.get(
                 f"{self._host}/api/2.1/jobs/runs/get",
@@ -158,13 +160,53 @@ class DatabricksService(IDatabricksService):
                 execution_duration_ms = data.get("execution_duration", 0)
                 setup_duration_ms = data.get("setup_duration", 0)
                 cleanup_duration_ms = data.get("cleanup_duration", 0)
-                execution_duration_s = execution_duration_ms / 1000
                 logger.info(
                     f"Databricks run {run_id} completed successfully. "
                     f"setup={setup_duration_ms / 1000:.1f}s, "
-                    f"execution={execution_duration_s:.1f}s, "
+                    f"execution={execution_duration_ms / 1000:.1f}s, "
                     f"cleanup={cleanup_duration_ms / 1000:.1f}s"
                 )
-                return execution_duration_s
+                return
 
             time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+
+    def _fetch_notebook_output(self, run_id: str) -> tuple[float, int]:
+        """Fetch the notebook's dbutils.notebookExit JSON payload and return (elapsed_seconds, cardinality)."""
+        response = requests.get(
+            f"{self._host}/api/2.1/jobs/runs/get-output",
+            headers=self._headers,
+            params={"run_id": run_id},
+            timeout=30,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+        notebook_output = payload.get("notebook_output", {})
+        raw_result = notebook_output.get("result")
+        if not raw_result:
+            raise RuntimeError(
+                f"Databricks run {run_id} produced no notebook_output.result. "
+                f"Expected JSON with 'elapsed_seconds' and 'cardinality'."
+            )
+
+        try:
+            parsed = json.loads(raw_result)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Databricks run {run_id} notebook_output.result is not valid JSON: {raw_result!r}"
+            ) from exc
+
+        try:
+            elapsed_seconds = float(parsed["elapsed_seconds"])
+            cardinality = int(parsed["cardinality"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"Databricks run {run_id} notebook_output.result missing required fields. "
+                f"Got: {parsed!r}"
+            ) from exc
+
+        logger.info(
+            f"Databricks run {run_id} notebook output: "
+            f"elapsed_seconds={elapsed_seconds:.3f}, cardinality={cardinality}"
+        )
+        return elapsed_seconds, cardinality

--- a/src/presentation/databricks/national_scale_spatial_join.py
+++ b/src/presentation/databricks/national_scale_spatial_join.py
@@ -2,6 +2,9 @@
 
 # COMMAND ----------
 
+import json
+import time
+
 from sedona.spark import SedonaContext
 
 # COMMAND ----------
@@ -52,6 +55,8 @@ municipalities_df.createOrReplaceTempView("municipalities")
 
 # COMMAND ----------
 
+start_time = time.perf_counter()
+
 result = sedona.sql("""
     SELECT
         m.municipality_name,
@@ -63,5 +68,12 @@ result = sedona.sql("""
     ORDER BY building_count DESC
 """)
 
-count = result.count()
-print(f"Spatial join complete. Regions with matched buildings: {count}")
+cardinality = result.count()
+elapsed_seconds = time.perf_counter() - start_time
+
+print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
+print(f"Elapsed seconds: {elapsed_seconds:.3f}")
+
+dbutils.notebookExit(
+    json.dumps({"elapsed_seconds": elapsed_seconds, "cardinality": cardinality})
+)

--- a/src/presentation/entrypoints/attribute_spatial_compound_filter_duckdb.py
+++ b/src/presentation/entrypoints/attribute_spatial_compound_filter_duckdb.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def attribute_spatial_compound_filter_duckdb(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -30,7 +30,7 @@ def attribute_spatial_compound_filter_duckdb(
 
     min_lon, min_lat, max_lon, max_lat = BoundingBox.NEIGHBORHOOD_WGS84.value
 
-    db_context.execute(
+    return db_context.execute(
         f"""
         SELECT * FROM read_parquet('{path}')
         WHERE source = ?
@@ -40,4 +40,4 @@ def attribute_spatial_compound_filter_duckdb(
         );
         """,
         [DataSource.OSM.value, min_lon, min_lat, max_lon, max_lat],
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/attribute_spatial_compound_filter_postgis.py
+++ b/src/presentation/entrypoints/attribute_spatial_compound_filter_postgis.py
@@ -15,7 +15,7 @@ from src.infra.infrastructure import Containers
 )
 def attribute_spatial_compound_filter_postgis(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     min_lon, min_lat, max_lon, max_lat = BoundingBox.NEIGHBORHOOD_WGS84.value
 
     sql = text(
@@ -31,10 +31,8 @@ def attribute_spatial_compound_filter_postgis(
     )
 
     with db_context.connect() as conn:
-        result = conn.execute(sql, {
+        return conn.execute(sql, {
             "source": DataSource.OSM.value,
             "min_lon": min_lon, "min_lat": min_lat,
             "max_lon": max_lon, "max_lat": max_lat,
-        })
-
-        result.fetchall()
+        }).fetchall()

--- a/src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py
+++ b/src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def bbox_filtering_advanced_duckdb(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -73,7 +73,7 @@ def bbox_filtering_advanced_duckdb(
         FROM filtered;
     """
 
-    db_context.execute(
+    return db_context.execute(
         query,
         [min_lon, min_lat, max_lon, max_lat],
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/bbox_filtering_advanced_postgis.py
+++ b/src/presentation/entrypoints/bbox_filtering_advanced_postgis.py
@@ -15,7 +15,7 @@ from src.infra.infrastructure import Containers
 )
 def bbox_filtering_advanced_postgis(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     # Same bbox as in the DuckDB example (Oslo-ish, WGS84 lon/lat)
     min_lon = 10.40
     max_lon = 10.95
@@ -55,7 +55,7 @@ def bbox_filtering_advanced_postgis(
     )
 
     with db_context.connect() as conn:
-        _ = conn.execute(
+        return conn.execute(
             sql,
             {
                 "min_lon": min_lon,
@@ -63,4 +63,4 @@ def bbox_filtering_advanced_postgis(
                 "max_lon": max_lon,
                 "max_lat": max_lat,
             },
-        ).fetchone()
+        ).fetchall()

--- a/src/presentation/entrypoints/bbox_filtering_result_set_sizes_county_duckdb.py
+++ b/src/presentation/entrypoints/bbox_filtering_result_set_sizes_county_duckdb.py
@@ -22,7 +22,7 @@ def bbox_filtering_result_set_sizes_county_duckdb() -> None:
 def _benchmark(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -34,7 +34,7 @@ def _benchmark(
 
     min_lon, min_lat, max_lon, max_lat = BoundingBox.TRONDELAG_WGS84.value
 
-    db_context.execute(
+    return db_context.execute(
         f"""
         SELECT *, ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) AS area
         FROM read_parquet('{path}')
@@ -45,4 +45,4 @@ def _benchmark(
         AND ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) > 10;
         """,
         [min_lon, min_lat, max_lon, max_lat],
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/bbox_filtering_result_set_sizes_county_postgis.py
+++ b/src/presentation/entrypoints/bbox_filtering_result_set_sizes_county_postgis.py
@@ -19,7 +19,7 @@ def bbox_filtering_result_set_sizes_county_postgis() -> None:
 )
 def _benchmark(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     min_lon, min_lat, max_lon, max_lat = BoundingBox.TRONDELAG_WGS84.value
 
     sql = text(
@@ -35,7 +35,7 @@ def _benchmark(
     )
 
     with db_context.connect() as conn:
-        conn.execute(
+        return conn.execute(
             sql,
             {
                 "min_lon": min_lon,

--- a/src/presentation/entrypoints/bbox_filtering_result_set_sizes_municipality_duckdb.py
+++ b/src/presentation/entrypoints/bbox_filtering_result_set_sizes_municipality_duckdb.py
@@ -22,7 +22,7 @@ def bbox_filtering_result_set_sizes_municipality_duckdb() -> None:
 def _benchmark(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -34,7 +34,7 @@ def _benchmark(
 
     min_lon, min_lat, max_lon, max_lat = BoundingBox.TRONDHEIM_WGS84.value
 
-    db_context.execute(
+    return db_context.execute(
         f"""
         SELECT *, ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) AS area
         FROM read_parquet('{path}')
@@ -45,4 +45,4 @@ def _benchmark(
         AND ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) > 10;
         """,
         [min_lon, min_lat, max_lon, max_lat],
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/bbox_filtering_result_set_sizes_municipality_postgis.py
+++ b/src/presentation/entrypoints/bbox_filtering_result_set_sizes_municipality_postgis.py
@@ -19,7 +19,7 @@ def bbox_filtering_result_set_sizes_municipality_postgis() -> None:
 )
 def _benchmark(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     min_lon, min_lat, max_lon, max_lat = BoundingBox.TRONDHEIM_WGS84.value
 
     sql = text(
@@ -35,7 +35,7 @@ def _benchmark(
     )
 
     with db_context.connect() as conn:
-        conn.execute(
+        return conn.execute(
             sql,
             {
                 "min_lon": min_lon,

--- a/src/presentation/entrypoints/bbox_filtering_result_set_sizes_neighborhood_duckdb.py
+++ b/src/presentation/entrypoints/bbox_filtering_result_set_sizes_neighborhood_duckdb.py
@@ -22,7 +22,7 @@ def bbox_filtering_result_set_sizes_neighborhood_duckdb() -> None:
 def _benchmark(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -34,7 +34,7 @@ def _benchmark(
 
     min_lon, min_lat, max_lon, max_lat = BoundingBox.NEIGHBORHOOD_WGS84.value
 
-    db_context.execute(
+    return db_context.execute(
         f"""
         SELECT *, ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) AS area
         FROM read_parquet('{path}')
@@ -45,4 +45,4 @@ def _benchmark(
         AND ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) > 10;
         """,
         [min_lon, min_lat, max_lon, max_lat],
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/bbox_filtering_result_set_sizes_neighborhood_postgis.py
+++ b/src/presentation/entrypoints/bbox_filtering_result_set_sizes_neighborhood_postgis.py
@@ -19,7 +19,7 @@ def bbox_filtering_result_set_sizes_neighborhood_postgis() -> None:
 )
 def _benchmark(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     min_lon, min_lat, max_lon, max_lat = BoundingBox.NEIGHBORHOOD_WGS84.value
 
     sql = text(
@@ -35,7 +35,7 @@ def _benchmark(
     )
 
     with db_context.connect() as conn:
-        conn.execute(
+        return conn.execute(
             sql,
             {
                 "min_lon": min_lon,

--- a/src/presentation/entrypoints/bbox_filtering_simple_blob_storage.py
+++ b/src/presentation/entrypoints/bbox_filtering_simple_blob_storage.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def bbox_filtering_simple_blob_storage(
         db_context: duckdb.DuckDBPyConnection = Provide[Containers.duckdb_context],
         file_path_service: IFilePathService = Provide[Containers.file_path_service]
-) -> None:
+) -> list:
     min_lon = 10.40
     max_lon = 10.95
     min_lat = 59.70
@@ -33,7 +33,7 @@ def bbox_filtering_simple_blob_storage(
         file_name="*.parquet"
     )
 
-    db_context.execute(
+    return db_context.execute(
         f"""
             SELECT *, ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) AS area
             FROM read_parquet('{path}')
@@ -43,4 +43,4 @@ def bbox_filtering_simple_blob_storage(
             )
             AND ST_Area(ST_Transform(geometry, 'EPSG:4326', 'EPSG:25832')) > 10;
             """
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/db_scan_blob_storage.py
+++ b/src/presentation/entrypoints/db_scan_blob_storage.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def db_scan_blob_storage(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service]
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -28,4 +28,4 @@ def db_scan_blob_storage(
         file_name="*.parquet"
     )
 
-    db_context.execute(f"SELECT count(*) AS count FROM read_parquet('{path}')")
+    return db_context.execute(f"SELECT count(*) AS count FROM read_parquet('{path}')").fetchall()

--- a/src/presentation/entrypoints/db_scan_postgis.py
+++ b/src/presentation/entrypoints/db_scan_postgis.py
@@ -15,6 +15,6 @@ from src.infra.infrastructure import Containers
 )
 def db_scan_postgis(
         db_context: Engine = Provide[Containers.postgres_context]
-) -> None:
+) -> list:
     with db_context.connect() as conn:
-        conn.execute(text("SELECT count(*) AS count FROM buildings")).scalar_one()
+        return [conn.execute(text("SELECT count(*) AS count FROM buildings")).scalar_one()]

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_2_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_2_nodes.py
@@ -24,5 +24,5 @@ def national_scale_spatial_join_databricks_2_nodes(
 )
 def _benchmark(
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> float:
+) -> tuple[float, int]:
     return databricks_service.submit_and_wait(num_workers=2)

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_4_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_4_nodes.py
@@ -24,5 +24,5 @@ def national_scale_spatial_join_databricks_4_nodes(
 )
 def _benchmark(
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> float:
+) -> tuple[float, int]:
     return databricks_service.submit_and_wait(num_workers=4)

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_8_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_8_nodes.py
@@ -24,5 +24,5 @@ def national_scale_spatial_join_databricks_8_nodes(
 )
 def _benchmark(
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> float:
+) -> tuple[float, int]:
     return databricks_service.submit_and_wait(num_workers=8)

--- a/src/presentation/entrypoints/national_scale_spatial_join_duckdb.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_duckdb.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def national_scale_spatial_join_duckdb(
     db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
     path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     buildings_path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -29,7 +29,7 @@ def national_scale_spatial_join_duckdb(
     )
     counties_path = f"az://{StorageContainer.METADATA.value}/{Config.DATABRICKS_MUNICIPALITIES_FILE}"
 
-    db_context.execute(f"""
+    return db_context.execute(f"""
         WITH counties AS (
             SELECT
                 region AS county_name,
@@ -44,4 +44,4 @@ def national_scale_spatial_join_duckdb(
           ON ST_Intersects(c.geometry, b.geometry)
         GROUP BY c.county_name
         ORDER BY building_count DESC
-    """)
+    """).fetchall()

--- a/src/presentation/entrypoints/national_scale_spatial_join_postgis.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_postgis.py
@@ -53,7 +53,7 @@ def _seed_counties(
 )
 def _benchmark(
     db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     sql = text("""
         SELECT
             c.county_name,
@@ -65,4 +65,4 @@ def _benchmark(
     """)
 
     with db_context.connect() as conn:
-        conn.execute(sql).fetchall()
+        return conn.execute(sql).fetchall()

--- a/src/presentation/entrypoints/ordered_range_query_duckdb.py
+++ b/src/presentation/entrypoints/ordered_range_query_duckdb.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def ordered_range_query_duckdb(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -30,7 +30,7 @@ def ordered_range_query_duckdb(
 
     min_lon, min_lat, max_lon, max_lat = BoundingBox.TRONDELAG_WGS84.value
 
-    db_context.execute(
+    return db_context.execute(
         f"""
         SELECT * FROM read_parquet('{path}')
         WHERE ST_Intersects(
@@ -41,4 +41,4 @@ def ordered_range_query_duckdb(
         LIMIT 1000;
         """,
         [min_lon, min_lat, max_lon, max_lat],
-    )
+    ).fetchall()

--- a/src/presentation/entrypoints/ordered_range_query_postgis.py
+++ b/src/presentation/entrypoints/ordered_range_query_postgis.py
@@ -15,7 +15,7 @@ from src.infra.infrastructure import Containers
 )
 def ordered_range_query_postgis(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     min_lon, min_lat, max_lon, max_lat = BoundingBox.TRONDELAG_WGS84.value
 
     sql = text(
@@ -32,9 +32,7 @@ def ordered_range_query_postgis(
     )
 
     with db_context.connect() as conn:
-        result = conn.execute(sql, {
+        return conn.execute(sql, {
             "min_lon": min_lon, "min_lat": min_lat,
             "max_lon": max_lon, "max_lat": max_lat,
-        })
-
-        result.fetchall()
+        }).fetchall()

--- a/src/presentation/entrypoints/point_in_polygon_lookup_duckdb.py
+++ b/src/presentation/entrypoints/point_in_polygon_lookup_duckdb.py
@@ -87,7 +87,7 @@ def _benchmark(
     points: list[tuple[float, float]],
     db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
     path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -97,11 +97,15 @@ def _benchmark(
         file_name="*.parquet",
     )
 
+    rows: list = []
     for lon, lat in points:
-        db_context.execute(
-            f"""
-            SELECT COUNT(*) FROM read_parquet('{path}')
-            WHERE ST_Contains(geometry, ST_Point(?, ?))
-            """,
-            [lon, lat],
+        rows.extend(
+            db_context.execute(
+                f"""
+                SELECT COUNT(*) FROM read_parquet('{path}')
+                WHERE ST_Contains(geometry, ST_Point(?, ?))
+                """,
+                [lon, lat],
+            ).fetchall()
         )
+    return rows

--- a/src/presentation/entrypoints/point_in_polygon_lookup_postgis.py
+++ b/src/presentation/entrypoints/point_in_polygon_lookup_postgis.py
@@ -80,13 +80,15 @@ def _generate_points(db_context: Engine) -> list[tuple[float, float]]:
 def _benchmark(
     points: list[tuple[float, float]],
     db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     sql = text("""
         SELECT COUNT(*)
         FROM buildings
         WHERE ST_Contains(geometry, ST_SetSRID(ST_Point(:lon, :lat), 4326))
         """)
 
+    results: list = []
     with db_context.connect() as conn:
         for lon, lat in points:
-            conn.execute(sql, {"lon": lon, "lat": lat}).scalar_one()
+            results.append(conn.execute(sql, {"lon": lon, "lat": lat}).scalar_one())
+    return results

--- a/src/presentation/entrypoints/spatial_aggregation_grid_duckdb.py
+++ b/src/presentation/entrypoints/spatial_aggregation_grid_duckdb.py
@@ -18,7 +18,7 @@ from src.infra.infrastructure import Containers
 def spatial_aggregation_grid_duckdb(
         db_context: DuckDBPyConnection = Provide[Containers.duckdb_context],
         path_service: IFilePathService = Provide[Containers.file_path_service],
-) -> None:
+) -> list:
     path = path_service.create_release_virtual_filesystem_path(
         storage_scheme="az",
         release=Config.BENCHMARK_DOPPA_DATA_RELEASE,
@@ -45,4 +45,4 @@ def spatial_aggregation_grid_duckdb(
         ORDER BY building_count DESC;
     """
 
-    db_context.execute(query, [cell_size, cell_size])
+    return db_context.execute(query, [cell_size, cell_size]).fetchall()

--- a/src/presentation/entrypoints/spatial_aggregation_grid_postgis.py
+++ b/src/presentation/entrypoints/spatial_aggregation_grid_postgis.py
@@ -15,7 +15,7 @@ from src.infra.infrastructure import Containers
 )
 def spatial_aggregation_grid_postgis(
         db_context: Engine = Provide[Containers.postgres_context],
-) -> None:
+) -> list:
     sql = text(
         """
         WITH building_centroids AS (
@@ -34,4 +34,4 @@ def spatial_aggregation_grid_postgis(
     )
 
     with db_context.connect() as conn:
-        _ = conn.execute(sql).fetchall()
+        return conn.execute(sql).fetchall()


### PR DESCRIPTION
This pull request introduces several improvements to how benchmarking and monitoring are handled, especially for Databricks runs, and standardizes the way result cardinality and execution time are collected and reported. It also updates the entrypoint functions to consistently return result sets, and introduces a schema version for monitoring records. The most important changes are summarized below.

**Benchmarking and Monitoring Enhancements:**

* The monitoring logic now collects additional metrics: CPU time (user and system), precise start/end timestamps, and result cardinality for each run. The schema version is also tracked in monitoring records. (`src/application/common/monitor.py`, `src/application/common/monitor_utils.py`, `src/domain/enums/schema_version.py`, `src/domain/enums/__init__.py`) [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL9-R15) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL67-R83) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR99-R104) [[4]](diffhunk://#diff-47aa54462bfb662354ffd8d94d9b3c69743ab69838339174abf1925081c10617L168-R193) [[5]](diffhunk://#diff-79ec56d13205a15c9e91072878b274b6f732af5c885c18195c185f3d7079bb4fR1-R5) [[6]](diffhunk://#diff-f67e0ea3db24648f04d7ce3f43496c85e29ab512e6ef89131891d23f4928c842R10)
* The monitoring decorator and internal measurement utilities now expect the wrapped function to optionally return a tuple of (elapsed_seconds, cardinality), supporting Databricks runs that self-report these values. (`src/application/common/monitor.py`, `src/application/contracts/databricks_service_interface.py`) [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL32-R32) [[2]](diffhunk://#diff-14119b5b2629edaab0d490f65545d6217d73cc8d299e959af74776cb1324cb07L6-R13)

**Databricks Integration Improvements:**

* The Databricks service now fetches and parses the notebook's output as JSON, extracting both elapsed time and result cardinality, and returns these as a tuple. The Databricks notebook is updated to emit these values via `dbutils.notebookExit`. (`src/infra/infrastructure/services/databricks_service.py`, `src/presentation/databricks/national_scale_spatial_join.py`) [[1]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L37-R45) [[2]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L131-R134) [[3]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L161-R212) [[4]](diffhunk://#diff-5c1c060c179248df12892efb096b2457a0114a1d13e16bf096ef45009d92552cR58-R59) [[5]](diffhunk://#diff-5c1c060c179248df12892efb096b2457a0114a1d13e16bf096ef45009d92552cL66-R79)

**Entrypoint Function Consistency:**

* All DuckDB and PostGIS entrypoint functions now return their result sets as lists, instead of returning `None`. This ensures that the monitoring logic can consistently determine result cardinality. (`src/presentation/entrypoints/attribute_spatial_compound_filter_duckdb.py`, `src/presentation/entrypoints/attribute_spatial_compound_filter_postgis.py`, `src/presentation/entrypoints/bbox_filtering_advanced_duckdb.py`, `src/presentation/entrypoints/bbox_filtering_advanced_postgis.py`, `src/presentation/entrypoints/bbox_filtering_result_set_sizes_county_duckdb.py`, `src/presentation/entrypoints/bbox_filtering_result_set_sizes_county_postgis.py`) [[1]](diffhunk://#diff-a15eb507e814dde1c3597b2a5d6ff58bc87c41bf4b3d8a1e6ba420ce0af9ce74L21-R21) [[2]](diffhunk://#diff-a15eb507e814dde1c3597b2a5d6ff58bc87c41bf4b3d8a1e6ba420ce0af9ce74L33-R33) [[3]](diffhunk://#diff-a15eb507e814dde1c3597b2a5d6ff58bc87c41bf4b3d8a1e6ba420ce0af9ce74L43-R43) [[4]](diffhunk://#diff-25cffc3ec625ae5c40b3864db754842b86a0a81fdf9ab07e6d535fd54926c433L18-R18) [[5]](diffhunk://#diff-25cffc3ec625ae5c40b3864db754842b86a0a81fdf9ab07e6d535fd54926c433L34-R38) [[6]](diffhunk://#diff-9c015ddeac1ef1ac033e012fef2cc245f8b4c42f6555e62e18661b241e6c3384L21-R21) [[7]](diffhunk://#diff-9c015ddeac1ef1ac033e012fef2cc245f8b4c42f6555e62e18661b241e6c3384L76-R79) [[8]](diffhunk://#diff-5135decf0ac8711af67127f6b83fff5de1adcf6371d188de34b3760814bb260dL18-R18) [[9]](diffhunk://#diff-5135decf0ac8711af67127f6b83fff5de1adcf6371d188de34b3760814bb260dL58-R66) [[10]](diffhunk://#diff-5a72ce8ba20d387eeaf9a832e86e64017d0335929db1cb8d08d6427fb6ebae09L25-R25) [[11]](diffhunk://#diff-5a72ce8ba20d387eeaf9a832e86e64017d0335929db1cb8d08d6427fb6ebae09L37-R37) [[12]](diffhunk://#diff-5a72ce8ba20d387eeaf9a832e86e64017d0335929db1cb8d08d6427fb6ebae09L48-R48) [[13]](diffhunk://#diff-e64604c427cce199dce1017607e5313b84038538ecc6eae78482ae41a070c8a4L22-R22) [[14]](diffhunk://#diff-e64604c427cce199dce1017607e5313b84038538ecc6eae78482ae41a070c8a4L38-R38)

**Schema Versioning:**

* Introduced a `SchemaVersion` enum and included a schema version field in all monitoring records to support future extensibility. (`src/domain/enums/schema_version.py`, `src/domain/enums/__init__.py`, `src/application/common/monitor.py`) [[1]](diffhunk://#diff-79ec56d13205a15c9e91072878b274b6f732af5c885c18195c185f3d7079bb4fR1-R5) [[2]](diffhunk://#diff-f67e0ea3db24648f04d7ce3f43496c85e29ab512e6ef89131891d23f4928c842R10) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR99-R104)

These changes improve the robustness and consistency of benchmarking, especially for cloud and distributed environments like Databricks, and lay the groundwork for future schema evolution.