### PR TITLE
Feature/248 add spark phase level metrics to the databricks national scale spatial join

### DIFF
--- a/src/application/common/monitor.py
+++ b/src/application/common/monitor.py
@@ -11,7 +11,7 @@ from src.application.common.monitor_utils import (
     _save_run_metadata,
     _save_run_cost_analytics,
 )
-from src.application.dtos import CostConfiguration
+from src.application.dtos import CostConfiguration, DatabricksRunResult
 from src.domain.enums import BenchmarkIteration, BlobOperationType, SchemaVersion
 
 
@@ -76,8 +76,25 @@ def monitor(
                 ) = _measure_io(func, *args, **kwargs)
                 ended_at = datetime.datetime.now(datetime.UTC)
 
+                executor_input_bytes_read = None
+                executor_run_time_ms = None
+                shuffle_read_bytes = None
+                shuffle_write_bytes = None
+                driver_collection_time_ms = None
+                stage_durations_ms = None
+
                 if elapsed_from_result:
-                    elapsed_time, result_cardinality = result
+                    if isinstance(result, DatabricksRunResult):
+                        elapsed_time = result.execution_duration_s
+                        result_cardinality = result.cardinality
+                        executor_input_bytes_read = result.executor_input_bytes_read
+                        executor_run_time_ms = result.executor_run_time_ms
+                        shuffle_read_bytes = result.shuffle_read_bytes
+                        shuffle_write_bytes = result.shuffle_write_bytes
+                        driver_collection_time_ms = result.driver_collection_time_ms
+                        stage_durations_ms = result.stage_durations_ms
+                    else:
+                        elapsed_time, result_cardinality = result
                 else:
                     elapsed_time = wall_elapsed_time
                     result_cardinality = len(result) if result is not None else -1
@@ -101,7 +118,13 @@ def monitor(
                             "cpu_time_user_seconds": cpu_time_user_seconds,
                             "cpu_time_system_seconds": cpu_time_system_seconds,
                             "result_cardinality": result_cardinality,
-                            "schema_version": SchemaVersion.V2.value,
+                            "executor_input_bytes_read": executor_input_bytes_read,
+                            "executor_run_time_ms": executor_run_time_ms,
+                            "shuffle_read_bytes": shuffle_read_bytes,
+                            "shuffle_write_bytes": shuffle_write_bytes,
+                            "driver_collection_time_ms": driver_collection_time_ms,
+                            "stage_durations_ms": stage_durations_ms,
+                            "schema_version": SchemaVersion.V3.value,
                         }
                     ],
                 )

--- a/src/application/contracts/databricks_service_interface.py
+++ b/src/application/contracts/databricks_service_interface.py
@@ -1,15 +1,18 @@
 from abc import ABC, abstractmethod
 
+from src.application.dtos import DatabricksRunResult
+
 
 class IDatabricksService(ABC):
     @abstractmethod
-    def submit_and_wait(self, num_workers: int) -> tuple[float, int]:
+    def submit_and_wait(self, num_workers: int) -> DatabricksRunResult:
         """
         Submit a one-time Databricks run for the national-scale spatial join and block until it reaches
         a terminal state (TERMINATED, SKIPPED, or INTERNAL_ERROR).
         :param num_workers: Number of worker nodes to provision for the cluster.
-        :return: Tuple of (elapsed_seconds, cardinality) self-reported by the notebook via dbutils.notebookExit JSON.
-            elapsed_seconds measures the spatial join + count() only (excludes cluster provisioning, Sedona init, and teardown).
+        :return: DatabricksRunResult with execution_duration_s, cardinality, and the six Spark phase metrics
+            self-reported by the notebook via dbutils.notebookExit JSON. execution_duration_s measures the
+            spatial join + count() only (excludes cluster provisioning, Sedona init, and teardown).
         :raises RuntimeError: If the run finishes in a non-successful state or the notebook does not emit the expected JSON payload.
         """
         raise NotImplementedError

--- a/src/application/dtos/databricks.py
+++ b/src/application/dtos/databricks.py
@@ -27,3 +27,21 @@ class DatabricksPricing:
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict())
+
+
+@dataclass(frozen=True)
+class DatabricksRunResult:
+    execution_duration_s: float
+    cardinality: int
+    executor_input_bytes_read: int
+    executor_run_time_ms: int
+    shuffle_read_bytes: int
+    shuffle_write_bytes: int
+    driver_collection_time_ms: int
+    stage_durations_ms: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())

--- a/src/config.py
+++ b/src/config.py
@@ -114,7 +114,7 @@ class Config:
     BENCHMARK_FILE: Path = ROOT_DIR / "benchmarks.yml"
     RUN_ID_LENGTH: int = 6
     DEFAULT_SAMPLE_TIMEOUT: float = 0.01
-    BENCHMARK_RUNS: int = 3
+    BENCHMARK_RUNS: int = 1
     BENCHMARK_WARMUP_ITERATIONS: int = 5
     BENCHMARK_ITERATIONS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"

--- a/src/domain/enums/schema_version.py
+++ b/src/domain/enums/schema_version.py
@@ -3,3 +3,4 @@ from enum import Enum
 
 class SchemaVersion(Enum):
     V2 = "v2"
+    V3 = "v3"

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -42,8 +42,8 @@ class DatabricksService(IDatabricksService):
         logger.info(
             f"Submitted Databricks run {run_id} with {num_workers} worker(s). Polling for completion."
         )
-        self._wait_for_run(run_id)
-        return self._fetch_notebook_output(run_id)
+        task_run_id = self._wait_for_run(run_id)
+        return self._fetch_notebook_output(task_run_id)
 
     def _upload_notebook(self) -> None:
         folder = str(Path(Config.DATABRICKS_WORKSPACE_NOTEBOOK_PATH).parent)
@@ -131,16 +131,29 @@ class DatabricksService(IDatabricksService):
         run_id: str = str(response.json()["run_id"])
         return run_id
 
-    def _wait_for_run(self, run_id: str) -> None:
-        """Poll until terminal state. Logs API-reported durations for diagnostic purposes."""
+    def _wait_for_run(self, run_id: str) -> str:
+        """Poll until terminal state. Logs API-reported durations for diagnostic purposes.
+
+        Returns the task run id (sub-run under the parent job run), which is the id
+        required by /api/2.1/jobs/runs/get-output. Passing the parent run id to
+        get-output returns 400 Bad Request.
+        """
         while True:
-            response = requests.get(
-                f"{self._host}/api/2.1/jobs/runs/get",
-                headers=self._headers,
-                params={"run_id": run_id},
-                timeout=30,
-            )
-            response.raise_for_status()
+            try:
+                response = requests.get(
+                    f"{self._host}/api/2.1/jobs/runs/get",
+                    headers=self._headers,
+                    params={"run_id": run_id},
+                    timeout=30,
+                )
+                response.raise_for_status()
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                logger.warning(
+                    f"Transient network error polling run {run_id}: {exc}. "
+                    f"Retrying in {Config.DATABRICKS_POLL_INTERVAL_SECONDS}s."
+                )
+                time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+                continue
             data = response.json()
 
             state = data.get("state", {})
@@ -167,19 +180,37 @@ class DatabricksService(IDatabricksService):
                     f"execution={execution_duration_ms / 1000:.1f}s, "
                     f"cleanup={cleanup_duration_ms / 1000:.1f}s"
                 )
-                return
+                tasks = data.get("tasks") or []
+                if not tasks:
+                    raise RuntimeError(
+                        f"Databricks run {run_id} has no tasks in response payload; "
+                        f"cannot resolve task run id for notebook output."
+                    )
+                task_run_id = str(tasks[0].get("run_id"))
+                logger.info(
+                    f"Resolved task run id {task_run_id} for parent run {run_id}."
+                )
+                return task_run_id
 
             time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
 
     def _fetch_notebook_output(self, run_id: str) -> DatabricksRunResult:
-        """Fetch the notebook's dbutils.notebookExit JSON payload and return a DatabricksRunResult."""
+        """Fetch the notebook's dbutils.notebook.exit JSON payload and return a DatabricksRunResult.
+
+        run_id here must be the task run id (returned by _wait_for_run), not the parent
+        job run id from runs/submit.
+        """
         response = requests.get(
             f"{self._host}/api/2.1/jobs/runs/get-output",
             headers=self._headers,
             params={"run_id": run_id},
             timeout=30,
         )
-        response.raise_for_status()
+        if not response.ok:
+            raise RuntimeError(
+                f"Databricks runs/get-output failed for run {run_id}: "
+                f"{response.status_code} {response.reason}: {response.text}"
+            )
         payload = response.json()
 
         notebook_output = payload.get("notebook_output", {})

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -8,6 +8,7 @@ import requests
 from src import Config
 from src.application.common import logger
 from src.application.contracts import IDatabricksService
+from src.application.dtos import DatabricksRunResult
 
 _TERMINAL_STATES = {"TERMINATED", "SKIPPED", "INTERNAL_ERROR"}
 
@@ -35,7 +36,7 @@ class DatabricksService(IDatabricksService):
             "Content-Type": "application/json",
         }
 
-    def submit_and_wait(self, num_workers: int) -> tuple[float, int]:
+    def submit_and_wait(self, num_workers: int) -> DatabricksRunResult:
         self._upload_notebook()
         run_id = self._submit_run(num_workers)
         logger.info(
@@ -170,8 +171,8 @@ class DatabricksService(IDatabricksService):
 
             time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
 
-    def _fetch_notebook_output(self, run_id: str) -> tuple[float, int]:
-        """Fetch the notebook's dbutils.notebookExit JSON payload and return (elapsed_seconds, cardinality)."""
+    def _fetch_notebook_output(self, run_id: str) -> DatabricksRunResult:
+        """Fetch the notebook's dbutils.notebookExit JSON payload and return a DatabricksRunResult."""
         response = requests.get(
             f"{self._host}/api/2.1/jobs/runs/get-output",
             headers=self._headers,
@@ -186,7 +187,7 @@ class DatabricksService(IDatabricksService):
         if not raw_result:
             raise RuntimeError(
                 f"Databricks run {run_id} produced no notebook_output.result. "
-                f"Expected JSON with 'elapsed_seconds' and 'cardinality'."
+                f"Expected JSON with execution_duration_s, cardinality, and Spark phase metrics."
             )
 
         try:
@@ -197,8 +198,16 @@ class DatabricksService(IDatabricksService):
             ) from exc
 
         try:
-            elapsed_seconds = float(parsed["elapsed_seconds"])
-            cardinality = int(parsed["cardinality"])
+            result = DatabricksRunResult(
+                execution_duration_s=float(parsed["execution_duration_s"]),
+                cardinality=int(parsed["cardinality"]),
+                executor_input_bytes_read=int(parsed["executor_input_bytes_read"]),
+                executor_run_time_ms=int(parsed["executor_run_time_ms"]),
+                shuffle_read_bytes=int(parsed["shuffle_read_bytes"]),
+                shuffle_write_bytes=int(parsed["shuffle_write_bytes"]),
+                driver_collection_time_ms=int(parsed["driver_collection_time_ms"]),
+                stage_durations_ms=str(parsed["stage_durations_ms"]),
+            )
         except (KeyError, TypeError, ValueError) as exc:
             raise RuntimeError(
                 f"Databricks run {run_id} notebook_output.result missing required fields. "
@@ -207,6 +216,11 @@ class DatabricksService(IDatabricksService):
 
         logger.info(
             f"Databricks run {run_id} notebook output: "
-            f"elapsed_seconds={elapsed_seconds:.3f}, cardinality={cardinality}"
+            f"execution_duration_s={result.execution_duration_s:.3f}, "
+            f"cardinality={result.cardinality}, "
+            f"executor_run_time_ms={result.executor_run_time_ms}, "
+            f"shuffle_read_bytes={result.shuffle_read_bytes}, "
+            f"shuffle_write_bytes={result.shuffle_write_bytes}, "
+            f"driver_collection_time_ms={result.driver_collection_time_ms}"
         )
-        return elapsed_seconds, cardinality
+        return result

--- a/src/presentation/databricks/national_scale_spatial_join.py
+++ b/src/presentation/databricks/national_scale_spatial_join.py
@@ -2,6 +2,27 @@
 
 # COMMAND ----------
 
+# Thesis terminology -> Spark metric mapping
+# - "executor read time"     ~ executor_run_time_ms - shuffleReadTime
+#                              (the cold scan + per-record work)
+# - "shuffle"                = shuffle_read_bytes + shuffle_write_bytes (volume),
+#                              shuffle stage duration (time)
+# - "driver collection"      = driver_collection_time_ms (residual,
+#                              includes planning + final collect)
+#
+# Notes:
+# - stage_durations_ms is capped at the first 100 stages (dbutils.notebookExit
+#   has a payload cap around 1 MB); a warning is logged if truncation happens.
+# - driver_collection_time_ms is computed as
+#   wall_clock_ms - sum(stage_durations_ms); clamped to 0 with a warning if
+#   negative (autoscaling can make stages overlap and break the simple
+#   decomposition).
+# - inputMetrics.bytesRead is post-pushdown decompressed bytes inside the
+#   executor, not on-the-wire bytes. The on-the-wire counter comes from the
+#   ACI-level psutil.net_io_counters in monitor.py.
+
+# COMMAND ----------
+
 import json
 import time
 
@@ -43,7 +64,7 @@ municipalities_df = municipalities_raw.selectExpr(
 )
 
 # Repartition to match cluster parallelism so all nodes receive work.
-# defaultParallelism = num_workers × cores_per_node (e.g. 8 nodes × 4 cores = 32).
+# defaultParallelism = num_workers x cores_per_node (e.g. 8 nodes x 4 cores = 32).
 parallelism = spark.sparkContext.defaultParallelism
 print(f"Cluster parallelism: {parallelism}")
 print(f"Buildings partitions before repartition: {buildings_df.rdd.getNumPartitions()}")
@@ -52,6 +73,63 @@ buildings_df = buildings_df.repartition(parallelism)
 
 buildings_df.createOrReplaceTempView("buildings")
 municipalities_df.createOrReplaceTempView("municipalities")
+
+# COMMAND ----------
+
+# MAGIC %scala
+# MAGIC import org.apache.spark.scheduler.{
+# MAGIC   SparkListener,
+# MAGIC   SparkListenerStageCompleted
+# MAGIC }
+# MAGIC import scala.collection.mutable
+# MAGIC
+# MAGIC // Single-use listener: instantiated immediately before the timed action.
+# MAGIC // Aggregates per-stage metrics across every job the action triggers and
+# MAGIC // publishes the result as the global temp view `_phase_metrics`, which
+# MAGIC // the following PySpark cell reads.
+# MAGIC val phaseListener = new SparkListener {
+# MAGIC   private val stages =
+# MAGIC     mutable.ArrayBuffer.empty[(Int, Long, Long, Long, Long, Long, Long, Long)]
+# MAGIC
+# MAGIC   override def onStageCompleted(event: SparkListenerStageCompleted): Unit = {
+# MAGIC     val info = event.stageInfo
+# MAGIC     val metrics = info.taskMetrics
+# MAGIC     val submission = info.submissionTime.getOrElse(0L)
+# MAGIC     val completion = info.completionTime.getOrElse(0L)
+# MAGIC     val stageDuration = if (completion >= submission) completion - submission else 0L
+# MAGIC
+# MAGIC     stages.synchronized {
+# MAGIC       stages += ((
+# MAGIC         info.stageId,
+# MAGIC         stageDuration,
+# MAGIC         metrics.executorRunTime,
+# MAGIC         metrics.executorCpuTime / 1000000L, // ns -> ms
+# MAGIC         metrics.inputMetrics.bytesRead,
+# MAGIC         metrics.shuffleReadMetrics.totalBytesRead,
+# MAGIC         metrics.shuffleWriteMetrics.bytesWritten,
+# MAGIC         metrics.resultSize
+# MAGIC       ))
+# MAGIC
+# MAGIC       val snapshot = stages.toSeq
+# MAGIC       val df = spark
+# MAGIC         .createDataFrame(snapshot)
+# MAGIC         .toDF(
+# MAGIC           "stage_id",
+# MAGIC           "stage_duration_ms",
+# MAGIC           "executor_run_time_ms",
+# MAGIC           "executor_cpu_time_ms",
+# MAGIC           "input_bytes_read",
+# MAGIC           "shuffle_read_bytes",
+# MAGIC           "shuffle_write_bytes",
+# MAGIC           "result_size_bytes"
+# MAGIC         )
+# MAGIC       df.createOrReplaceGlobalTempView("_phase_metrics")
+# MAGIC     }
+# MAGIC   }
+# MAGIC }
+# MAGIC
+# MAGIC spark.sparkContext.addSparkListener(phaseListener)
+# MAGIC println("Phase-metrics SparkListener registered.")
 
 # COMMAND ----------
 
@@ -74,6 +152,58 @@ elapsed_seconds = time.perf_counter() - start_time
 print(f"Spatial join complete. Regions with matched buildings: {cardinality}")
 print(f"Elapsed seconds: {elapsed_seconds:.3f}")
 
-dbutils.notebookExit(
-    json.dumps({"elapsed_seconds": elapsed_seconds, "cardinality": cardinality})
-)
+# COMMAND ----------
+
+from pyspark.sql import functions as F
+
+_STAGE_DURATION_CAP = 100
+
+phase_df = spark.read.table("global_temp._phase_metrics").orderBy("stage_id")
+
+aggregates = phase_df.agg(
+    F.coalesce(F.sum("input_bytes_read"), F.lit(0)).alias("executor_input_bytes_read"),
+    F.coalesce(F.sum("executor_run_time_ms"), F.lit(0)).alias("executor_run_time_ms"),
+    F.coalesce(F.sum("shuffle_read_bytes"), F.lit(0)).alias("shuffle_read_bytes"),
+    F.coalesce(F.sum("shuffle_write_bytes"), F.lit(0)).alias("shuffle_write_bytes"),
+    F.coalesce(F.sum("stage_duration_ms"), F.lit(0)).alias("sum_stage_duration_ms"),
+).collect()[0]
+
+stage_durations_rows = phase_df.select("stage_duration_ms").collect()
+stage_durations_all = [int(row["stage_duration_ms"]) for row in stage_durations_rows]
+if len(stage_durations_all) > _STAGE_DURATION_CAP:
+    print(
+        f"WARNING: {len(stage_durations_all)} stages observed; truncating "
+        f"stage_durations_ms to first {_STAGE_DURATION_CAP} to stay under the "
+        f"dbutils.notebookExit payload cap."
+    )
+    stage_durations = stage_durations_all[:_STAGE_DURATION_CAP]
+else:
+    stage_durations = stage_durations_all
+
+wall_clock_ms = int(round(elapsed_seconds * 1000.0))
+sum_stage_duration_ms = int(aggregates["sum_stage_duration_ms"])
+residual_ms = wall_clock_ms - sum_stage_duration_ms
+if residual_ms < 0:
+    print(
+        f"WARNING: stage durations sum ({sum_stage_duration_ms} ms) exceeds "
+        f"wall-clock ({wall_clock_ms} ms); clamping driver_collection_time_ms "
+        f"to 0. Stages likely overlapped (autoscaling)."
+    )
+    driver_collection_time_ms = 0
+else:
+    driver_collection_time_ms = residual_ms
+
+payload = {
+    "execution_duration_s": elapsed_seconds,
+    "cardinality": int(cardinality),
+    "executor_input_bytes_read": int(aggregates["executor_input_bytes_read"]),
+    "executor_run_time_ms": int(aggregates["executor_run_time_ms"]),
+    "shuffle_read_bytes": int(aggregates["shuffle_read_bytes"]),
+    "shuffle_write_bytes": int(aggregates["shuffle_write_bytes"]),
+    "driver_collection_time_ms": driver_collection_time_ms,
+    "stage_durations_ms": json.dumps(stage_durations),
+}
+
+print(f"Phase-metric payload: {payload}")
+
+dbutils.notebookExit(json.dumps(payload))

--- a/src/presentation/databricks/national_scale_spatial_join.py
+++ b/src/presentation/databricks/national_scale_spatial_join.py
@@ -11,7 +11,7 @@
 #                              includes planning + final collect)
 #
 # Notes:
-# - stage_durations_ms is capped at the first 100 stages (dbutils.notebookExit
+# - stage_durations_ms is capped at the first 100 stages (dbutils.notebook.exit
 #   has a payload cap around 1 MB); a warning is logged if truncation happens.
 # - driver_collection_time_ms is computed as
 #   wall_clock_ms - sum(stage_durations_ms); clamped to 0 with a warning if
@@ -174,7 +174,7 @@ if len(stage_durations_all) > _STAGE_DURATION_CAP:
     print(
         f"WARNING: {len(stage_durations_all)} stages observed; truncating "
         f"stage_durations_ms to first {_STAGE_DURATION_CAP} to stay under the "
-        f"dbutils.notebookExit payload cap."
+        f"dbutils.notebook.exit payload cap."
     )
     stage_durations = stage_durations_all[:_STAGE_DURATION_CAP]
 else:
@@ -206,4 +206,4 @@ payload = {
 
 print(f"Phase-metric payload: {payload}")
 
-dbutils.notebookExit(json.dumps(payload))
+dbutils.notebook.exit(json.dumps(payload))

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_2_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_2_nodes.py
@@ -2,7 +2,7 @@ from dependency_injector.wiring import Provide, inject
 
 from src.application.common.monitor import monitor
 from src.application.contracts import IDatabricksService
-from src.application.dtos import CostConfiguration
+from src.application.dtos import CostConfiguration, DatabricksRunResult
 from src.domain.enums import BenchmarkIteration
 from src.infra.infrastructure import Containers
 
@@ -24,5 +24,5 @@ def national_scale_spatial_join_databricks_2_nodes(
 )
 def _benchmark(
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> tuple[float, int]:
+) -> DatabricksRunResult:
     return databricks_service.submit_and_wait(num_workers=2)

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_4_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_4_nodes.py
@@ -2,7 +2,7 @@ from dependency_injector.wiring import Provide, inject
 
 from src.application.common.monitor import monitor
 from src.application.contracts import IDatabricksService
-from src.application.dtos import CostConfiguration
+from src.application.dtos import CostConfiguration, DatabricksRunResult
 from src.domain.enums import BenchmarkIteration
 from src.infra.infrastructure import Containers
 
@@ -24,5 +24,5 @@ def national_scale_spatial_join_databricks_4_nodes(
 )
 def _benchmark(
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> tuple[float, int]:
+) -> DatabricksRunResult:
     return databricks_service.submit_and_wait(num_workers=4)

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_8_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_8_nodes.py
@@ -2,7 +2,7 @@ from dependency_injector.wiring import Provide, inject
 
 from src.application.common.monitor import monitor
 from src.application.contracts import IDatabricksService
-from src.application.dtos import CostConfiguration
+from src.application.dtos import CostConfiguration, DatabricksRunResult
 from src.domain.enums import BenchmarkIteration
 from src.infra.infrastructure import Containers
 
@@ -24,5 +24,5 @@ def national_scale_spatial_join_databricks_8_nodes(
 )
 def _benchmark(
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> tuple[float, int]:
+) -> DatabricksRunResult:
     return databricks_service.submit_and_wait(num_workers=8)


### PR DESCRIPTION
This pull request introduces a significant enhancement to the Databricks benchmarking pipeline by capturing and propagating detailed Spark execution metrics throughout the stack. The changes update the Databricks notebook to emit a richer set of phase metrics, refactor interfaces and DTOs to carry this information, and update the monitoring and service layers to store and log these new metrics. Additionally, the schema version is incremented to v3 to reflect the expanded payload.

**Databricks metrics collection and propagation:**

* The Databricks notebook (`national_scale_spatial_join.py`) is updated to collect and emit detailed Spark phase metrics, including executor input bytes read, executor run time, shuffle read/write bytes, driver collection time, and per-stage durations. The notebook output payload is now a JSON object containing these metrics. [[1]](diffhunk://#diff-5c1c060c179248df12892efb096b2457a0114a1d13e16bf096ef45009d92552cR5-R25) [[2]](diffhunk://#diff-5c1c060c179248df12892efb096b2457a0114a1d13e16bf096ef45009d92552cR79-R135) [[3]](diffhunk://#diff-5c1c060c179248df12892efb096b2457a0114a1d13e16bf096ef45009d92552cL77-R209)
* A new `DatabricksRunResult` dataclass is introduced to encapsulate all these metrics, replacing the previous tuple-based approach.

**Service and contract layer updates:**

* The Databricks service interface (`IDatabricksService`) and its implementation are refactored to return and handle `DatabricksRunResult` instead of a simple tuple, ensuring the full metric payload is available to consumers. [[1]](diffhunk://#diff-14119b5b2629edaab0d490f65545d6217d73cc8d299e959af74776cb1324cb07R3-R15) [[2]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11R11) [[3]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L38-R46) [[4]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L133-R156) [[5]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L169-R221) [[6]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L200-R241) [[7]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L210-R257)
* Entrypoints and benchmarks are updated to use `DatabricksRunResult` throughout, ensuring type consistency. [[1]](diffhunk://#diff-e908265b978b252c28e8d775d70b33c68a0a2045f00c621ebdd9352cfbb48e1eL5-R5) [[2]](diffhunk://#diff-e908265b978b252c28e8d775d70b33c68a0a2045f00c621ebdd9352cfbb48e1eL27-R27) [[3]](diffhunk://#diff-c3a45b0798a207ee25f8bdf39309b59be4cefe7617c1922bf6e5d36dd9e68a98L5-R5)

**Monitoring and schema changes:**

* The monitoring layer is updated to store the new metrics in run metadata and increment the schema version to v3. [[1]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL14-R14) [[2]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fR79-R96) [[3]](diffhunk://#diff-86cbacf6408622a106a98e647c5f5f18d90a983b2592fa7f50e5f0ccaee25f9fL104-R127) [[4]](diffhunk://#diff-79ec56d13205a15c9e91072878b274b6f732af5c885c18195c185f3d7079bb4fR6)

**Other changes:**

* The default number of benchmark runs is set to 1 instead of 3, likely for faster iteration during development.

These changes collectively enable more granular and accurate performance analysis of Databricks runs, supporting advanced diagnostics and future benchmarking improvements.