### PR TITLE
#258 Cast region ID to string

### DIFF
--- a/src/infra/infrastructure/services/dataset_synthesis_service.py
+++ b/src/infra/infrastructure/services/dataset_synthesis_service.py
@@ -143,6 +143,9 @@ class DatasetSynthesisService(IDatasetSynthesisService):
 
         dataframe = dataframe.drop(columns=["bbox", "size", "theme"], errors="ignore")
 
+        if "region" in dataframe.columns:
+            dataframe["region"] = dataframe["region"].astype(str)
+
         geometry_array = dataframe["geometry"].to_numpy()
         geometry_array = np.array(
             [bytes(g) if isinstance(g, (bytearray, memoryview)) else g for g in geometry_array],


### PR DESCRIPTION
This pull request makes a small change to the `__read_source_polygons` method to ensure that the `region` column is always stored as a string type if it exists in the input dataframe. This helps maintain data consistency when processing geospatial data. 

* Data consistency improvement:
  * In `src/infra/infrastructure/services/dataset_synthesis_service.py`, the `region` column is explicitly cast to string type if it exists in the dataframe.