### PR TITLE
#263 Increased CPU and RAM

### DIFF
--- a/.github/workflows/setup-benchmarking-framework.yml
+++ b/.github/workflows/setup-benchmarking-framework.yml
@@ -68,8 +68,8 @@ jobs:
             --name container-setup-framework \
             --image ${{ vars.ACR_LOGIN_SERVER }}/setup-framework:latest \
             --location norwayeast \
-            --cpu 4 \
-            --memory 16 \
+            --cpu 8 \
+            --memory 32 \
             --os-type Linux \
             --restart-policy Never \
             --assign-identity "$AZURE_UAMI_RESOURCE_ID" \


### PR DESCRIPTION
This pull request increases the resources allocated to the benchmarking framework container in the GitHub Actions workflow. The CPU and memory limits have been doubled to improve performance.

Resource allocation update:

* Increased the container's CPU from 4 to 8 and memory from 16GB to 32GB in `.github/workflows/setup-benchmarking-framework.yml`.