### PR TITLE
Feature/262 reuse databricks cluster across benchmark iterations

### DIFF
--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -140,17 +140,17 @@ def benchmark_runner() -> None:
             return
         case "national-scale-spatial-join-databricks-2-nodes":
             national_scale_spatial_join_databricks_2_nodes(
-                dataset_size=DatasetSize.LARGE
+                dataset_size=DatasetSize.SMALL
             )
             return
         case "national-scale-spatial-join-databricks-4-nodes":
             national_scale_spatial_join_databricks_4_nodes(
-                dataset_size=DatasetSize.LARGE
+                dataset_size=DatasetSize.SMALL
             )
             return
         case "national-scale-spatial-join-databricks-8-nodes":
             national_scale_spatial_join_databricks_8_nodes(
-                dataset_size=DatasetSize.LARGE
+                dataset_size=DatasetSize.SMALL
             )
             return
         case "setup-framework":

--- a/benchmark_runner.py
+++ b/benchmark_runner.py
@@ -1,5 +1,6 @@
 ﻿import argparse
 from typing import Optional
+from src.domain.enums import DatasetSize
 from src.presentation.configuration import initialize_dependencies
 from src.presentation.entrypoints import (
     db_scan_blob_storage,
@@ -138,13 +139,19 @@ def benchmark_runner() -> None:
             national_scale_spatial_join_postgis()
             return
         case "national-scale-spatial-join-databricks-2-nodes":
-            national_scale_spatial_join_databricks_2_nodes()
+            national_scale_spatial_join_databricks_2_nodes(
+                dataset_size=DatasetSize.LARGE
+            )
             return
         case "national-scale-spatial-join-databricks-4-nodes":
-            national_scale_spatial_join_databricks_4_nodes()
+            national_scale_spatial_join_databricks_4_nodes(
+                dataset_size=DatasetSize.LARGE
+            )
             return
         case "national-scale-spatial-join-databricks-8-nodes":
-            national_scale_spatial_join_databricks_8_nodes()
+            national_scale_spatial_join_databricks_8_nodes(
+                dataset_size=DatasetSize.LARGE
+            )
             return
         case "setup-framework":
             setup_benchmarking_framework()

--- a/src/application/contracts/databricks_service_interface.py
+++ b/src/application/contracts/databricks_service_interface.py
@@ -1,21 +1,55 @@
 from abc import ABC, abstractmethod
 
 from src.application.dtos import DatabricksRunResult
+from src.domain.enums import DatasetSize
 
 
 class IDatabricksService(ABC):
     @abstractmethod
-    def submit_and_wait(self, num_workers: int) -> DatabricksRunResult:
+    def create_cluster(self, num_workers: int) -> str:
         """
-        Submit a one-time Databricks run for the national-scale spatial join and block until it
-        reaches a terminal state (TERMINATED, SKIPPED, or INTERNAL_ERROR).
+        Provision an interactive cluster, install required libraries, wait for the cluster to
+        reach RUNNING state and for all libraries to reach INSTALLED state, and upload the
+        benchmark notebook to the workspace.
+
         :param num_workers: Number of worker nodes to provision for the cluster.
-        :return: DatabricksRunResult with `execution_duration_s`, `cardinality`, and the six Spark
-            phase metrics self-reported by the notebook via `dbutils.notebook.exit` JSON.
-            `execution_duration_s` measures the spatial join + count() only (excludes cluster
-            provisioning, Sedona init, and teardown).
+        :return: The Databricks cluster ID, suitable for passing to
+            :meth:`submit_to_existing_cluster` and :meth:`terminate_cluster`.
+        :rtype: str
+        :raises RuntimeError: If the cluster fails to start, a library install fails or is
+            skipped, or the notebook upload fails. The partially-provisioned cluster is
+            terminated before the exception propagates.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def submit_to_existing_cluster(
+        self, cluster_id: str, num_workers: int, dataset_size: DatasetSize
+    ) -> DatabricksRunResult:
+        """
+        Submit a single notebook run against an already-running cluster and block until it
+        reaches a terminal state (TERMINATED, SKIPPED, or INTERNAL_ERROR).
+
+        :param cluster_id: The cluster ID returned by :meth:`create_cluster`.
+        :param num_workers: Number of worker nodes on the cluster. Used only to label the
+            Databricks run (e.g. ``national-scale-spatial-join-8-nodes``).
+        :param dataset_size: Which buildings dataset partition the notebook should read
+            (``size=small|medium|large`` under the release path).
+        :return: DatabricksRunResult with `execution_duration_s`, `cardinality`, and the six
+            Spark phase metrics self-reported by the notebook via `dbutils.notebook.exit`
+            JSON. `execution_duration_s` measures the spatial join + count() only.
         :rtype: DatabricksRunResult
-        :raises RuntimeError: If the run finishes in a non-successful state or the notebook does not
-            emit the expected JSON payload.
+        :raises RuntimeError: If the run finishes in a non-successful state or the notebook
+            does not emit the expected JSON payload.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def terminate_cluster(self, cluster_id: str) -> None:
+        """
+        Permanently delete the cluster. Safe to call from a ``finally`` block.
+
+        :param cluster_id: The cluster ID returned by :meth:`create_cluster`.
+        :raises RuntimeError: If the Databricks API rejects the delete request.
         """
         raise NotImplementedError

--- a/src/application/contracts/databricks_service_interface.py
+++ b/src/application/contracts/databricks_service_interface.py
@@ -32,7 +32,8 @@ class IDatabricksService(ABC):
 
         :param cluster_id: The cluster ID returned by :meth:`create_cluster`.
         :param num_workers: Number of worker nodes on the cluster. Used only to label the
-            Databricks run (e.g. ``national-scale-spatial-join-8-nodes``).
+            Databricks run (e.g. ``national-scale-spatial-join-8-nodes-small``, where the
+            trailing token is ``dataset_size.value``).
         :param dataset_size: Which buildings dataset partition the notebook should read
             (``size=small|medium|large`` under the release path).
         :return: DatabricksRunResult with `execution_duration_s`, `cardinality`, and the six

--- a/src/config.py
+++ b/src/config.py
@@ -107,7 +107,7 @@ class Config:
     BENCHMARK_WARMUP_ITERATIONS: int = 5
     BENCHMARK_ITERATIONS: int = 100
     BENCHMARK_METADATA_BLOB_NAME: str = "benchmark_metadata.parquet"
-    BENCHMARK_DOPPA_DATA_RELEASE: str = "2026-04-02.0"
+    BENCHMARK_DOPPA_DATA_RELEASE: str = "2026-05-16.1"
 
     INGESTION_DELAY_SECONDS: int = 600
 
@@ -121,12 +121,14 @@ class Config:
         "DATABRICKS_NODE_TYPE_ID", "Standard_D4s_v3"
     )
     DATABRICKS_POLL_INTERVAL_SECONDS: int = 30
+    DATABRICKS_HTTP_TIMEOUT_SECONDS: int = 30
     DATABRICKS_DRIVER_MEMORY: str = "9g"
     DATABRICKS_DRIVER_MEMORY_OVERHEAD: str = "512m"
     DATABRICKS_SEDONA_MAVEN_COORDINATES: str = (
         "org.apache.sedona:sedona-spark-shaded-3.5_2.12:1.7.1"
     )
     DATABRICKS_SEDONA_PYPI_PACKAGE: str = "apache-sedona==1.7.1"
+    DATABRICKS_GEOPANDAS_PYPI_PACKAGE: str = "geopandas==0.14.4"
     DATABRICKS_LOCAL_SCRIPT_PATH: str = (
         "src/presentation/databricks/national_scale_spatial_join.py"
     )

--- a/src/domain/enums/__init__.py
+++ b/src/domain/enums/__init__.py
@@ -2,6 +2,9 @@
 from .azure_resource_metrics import AzureResourceMetrics
 from .benchmark_iteration import BenchmarkIteration
 from .blob_operation_type import BlobOperationType
+from .databricks_cluster_state import DatabricksClusterState
+from .databricks_library_status import DatabricksLibraryStatus
+from .databricks_run_state import DatabricksRunLifecycleState, DatabricksRunResultState
 from .storage_container import StorageContainer
 from .epsg_code import EPSGCode
 from .theme import Theme

--- a/src/domain/enums/databricks_cluster_state.py
+++ b/src/domain/enums/databricks_cluster_state.py
@@ -1,0 +1,23 @@
+from enum import Enum
+
+
+class DatabricksClusterState(str, Enum):
+    """Cluster ``state`` values returned by the Databricks REST API.
+
+    Only the values the service compares against are enumerated. Any other state seen
+    in API responses is treated as a non-terminal "still working" state by the caller.
+    """
+
+    RUNNING = "RUNNING"
+    ERROR = "ERROR"
+    TERMINATED = "TERMINATED"
+    TERMINATING = "TERMINATING"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def non_running_terminal_values(cls) -> frozenset[str]:
+        """Raw state strings that indicate the cluster reached a terminal state
+        without ever entering RUNNING."""
+        return frozenset(
+            {cls.ERROR.value, cls.TERMINATED.value, cls.TERMINATING.value, cls.UNKNOWN.value}
+        )

--- a/src/domain/enums/databricks_library_status.py
+++ b/src/domain/enums/databricks_library_status.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+
+class DatabricksLibraryStatus(str, Enum):
+    """Library installation ``status`` values returned by the Databricks REST API.
+
+    Only the values the service compares against are enumerated.
+    """
+
+    INSTALLED = "INSTALLED"
+    FAILED = "FAILED"
+    SKIPPED = "SKIPPED"
+
+    @classmethod
+    def terminal_failure_values(cls) -> frozenset[str]:
+        """Raw status strings that indicate the library install will not succeed."""
+        return frozenset({cls.FAILED.value, cls.SKIPPED.value})

--- a/src/domain/enums/databricks_run_state.py
+++ b/src/domain/enums/databricks_run_state.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+
+class DatabricksRunLifecycleState(str, Enum):
+    """``life_cycle_state`` values returned for Databricks jobs/runs.
+
+    Only the values the service compares against are enumerated.
+    """
+
+    TERMINATED = "TERMINATED"
+    SKIPPED = "SKIPPED"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+    @classmethod
+    def terminal_values(cls) -> frozenset[str]:
+        """Raw lifecycle strings after which the run will not progress further."""
+        return frozenset(
+            {cls.TERMINATED.value, cls.SKIPPED.value, cls.INTERNAL_ERROR.value}
+        )
+
+
+class DatabricksRunResultState(str, Enum):
+    """``result_state`` values returned once a Databricks run reaches a terminal lifecycle."""
+
+    SUCCESS = "SUCCESS"

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -9,8 +9,13 @@ from src import Config
 from src.application.common import logger
 from src.application.contracts import IDatabricksService
 from src.application.dtos import DatabricksRunResult
-
-_TERMINAL_STATES = {"TERMINATED", "SKIPPED", "INTERNAL_ERROR"}
+from src.domain.enums import (
+    DatabricksClusterState,
+    DatabricksLibraryStatus,
+    DatabricksRunLifecycleState,
+    DatabricksRunResultState,
+    DatasetSize,
+)
 
 
 class DatabricksService(IDatabricksService):
@@ -36,14 +41,233 @@ class DatabricksService(IDatabricksService):
             "Content-Type": "application/json",
         }
 
-    def submit_and_wait(self, num_workers: int) -> DatabricksRunResult:
-        self._upload_notebook()
-        run_id = self._submit_run(num_workers)
+    def create_cluster(self, num_workers: int) -> str:
+        cluster_id = self._create_cluster(num_workers=num_workers)
+        try:
+            self._install_libraries(cluster_id=cluster_id)
+            self._wait_for_cluster_running(cluster_id=cluster_id)
+            self._wait_for_libraries_installed(cluster_id=cluster_id)
+            self._upload_notebook()
+        except Exception:
+            logger.warning(
+                f"Cluster {cluster_id} provisioning failed before it was returned to caller. "
+                f"Terminating to avoid orphan resources."
+            )
+            try:
+                self.terminate_cluster(cluster_id=cluster_id)
+            except Exception as termination_exc:
+                logger.error(
+                    f"Failed to terminate partially-provisioned cluster {cluster_id}: "
+                    f"{termination_exc}"
+                )
+            raise
         logger.info(
-            f"Submitted Databricks run {run_id} with {num_workers} worker(s). Polling for completion."
+            f"Cluster {cluster_id} ready with {num_workers} worker(s). "
+            f"Libraries installed, notebook uploaded."
+        )
+        return cluster_id
+
+    def submit_to_existing_cluster(
+        self, cluster_id: str, num_workers: int, dataset_size: DatasetSize
+    ) -> DatabricksRunResult:
+        run_id = self._submit_run(
+            cluster_id=cluster_id,
+            num_workers=num_workers,
+            dataset_size=dataset_size,
+        )
+        logger.info(
+            f"Submitted Databricks run {run_id} on cluster {cluster_id} "
+            f"against dataset size '{dataset_size.value}'. Polling for completion."
         )
         task_run_id = self._wait_for_run(run_id)
         return self._fetch_notebook_output(task_run_id)
+
+    def terminate_cluster(self, cluster_id: str) -> None:
+        response = requests.post(
+            f"{self._host}/api/2.1/clusters/permanent-delete",
+            headers=self._headers,
+            json={"cluster_id": cluster_id},
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"Failed to permanently delete cluster {cluster_id}: "
+                f"{response.status_code}: {response.text}"
+            )
+        logger.info(f"Permanently deleted cluster {cluster_id}.")
+
+    def _create_cluster(self, num_workers: int) -> str:
+        single_user_name = self._get_current_user_name()
+        payload = {
+            "cluster_name": f"doppa-national-scale-spatial-join-{num_workers}-nodes",
+            "spark_version": Config.DATABRICKS_SPARK_VERSION,
+            "node_type_id": Config.DATABRICKS_NODE_TYPE_ID,
+            "num_workers": num_workers,
+            "data_security_mode": "LEGACY_SINGLE_USER",
+            "single_user_name": single_user_name,
+            "spark_conf": {
+                "spark.driver.memory": Config.DATABRICKS_DRIVER_MEMORY,
+                "spark.driver.memoryOverhead": Config.DATABRICKS_DRIVER_MEMORY_OVERHEAD,
+                f"spark.hadoop.fs.azure.account.auth.type.{Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net": "SharedKey",
+                f"spark.hadoop.fs.azure.account.key.{Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME}.dfs.core.windows.net": Config.AZURE_BLOB_STORAGE_ACCOUNT_KEY,
+            },
+        }
+        response = requests.post(
+            f"{self._host}/api/2.1/clusters/create",
+            headers=self._headers,
+            json=payload,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"Databricks clusters/create failed with {response.status_code}: {response.text}"
+            )
+        cluster_id: str = str(response.json()["cluster_id"])
+        logger.info(
+            f"Created cluster {cluster_id} with {num_workers} worker(s) "
+            f"(LEGACY_SINGLE_USER mode, single_user_name='{single_user_name}')."
+        )
+        return cluster_id
+
+    def _get_current_user_name(self) -> str:
+        """Resolve the identity attached to the Databricks PAT.
+
+        Workspaces that enforce Unity Catalog reject /clusters/create requests without an
+        explicit ``data_security_mode``. ``SINGLE_USER`` mode requires ``single_user_name``,
+        which must match the caller's identity, so we look it up from SCIM ``/Me``.
+        """
+        response = requests.get(
+            f"{self._host}/api/2.0/preview/scim/v2/Me",
+            headers=self._headers,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"Failed to resolve current Databricks identity via SCIM /Me: "
+                f"{response.status_code}: {response.text}"
+            )
+        data = response.json()
+        user_name = data.get("userName")
+        if not user_name:
+            raise RuntimeError(
+                f"SCIM /Me did not return a userName. Payload: {data!r}"
+            )
+        return user_name
+
+    def _install_libraries(self, cluster_id: str) -> None:
+        payload = {
+            "cluster_id": cluster_id,
+            "libraries": [
+                {"maven": {"coordinates": Config.DATABRICKS_SEDONA_MAVEN_COORDINATES}},
+                {"pypi": {"package": Config.DATABRICKS_SEDONA_PYPI_PACKAGE}},
+                {"pypi": {"package": Config.DATABRICKS_GEOPANDAS_PYPI_PACKAGE}},
+            ],
+        }
+        response = requests.post(
+            f"{self._host}/api/2.0/libraries/install",
+            headers=self._headers,
+            json=payload,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
+        )
+        if not response.ok:
+            raise RuntimeError(
+                f"Databricks libraries/install failed for cluster {cluster_id}: "
+                f"{response.status_code}: {response.text}"
+            )
+        logger.info(f"Requested library install on cluster {cluster_id}.")
+
+    def _wait_for_cluster_running(self, cluster_id: str) -> None:
+        while True:
+            try:
+                response = requests.get(
+                    f"{self._host}/api/2.1/clusters/get",
+                    headers=self._headers,
+                    params={"cluster_id": cluster_id},
+                    timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
+                )
+                response.raise_for_status()
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                logger.warning(
+                    f"Transient network error polling cluster {cluster_id}: {exc}. "
+                    f"Retrying in {Config.DATABRICKS_POLL_INTERVAL_SECONDS}s."
+                )
+                time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+                continue
+            data = response.json()
+            state = data.get("state", "")
+            logger.info(f"Cluster {cluster_id}: state={state}")
+            if state == DatabricksClusterState.RUNNING.value:
+                return
+            if state in DatabricksClusterState.non_running_terminal_values():
+                state_message = data.get("state_message", "")
+                raise RuntimeError(
+                    f"Cluster {cluster_id} reached unexpected state '{state}' "
+                    f"before RUNNING. State message: {state_message}"
+                )
+            time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+
+    def _wait_for_libraries_installed(self, cluster_id: str) -> None:
+        while True:
+            try:
+                response = requests.get(
+                    f"{self._host}/api/2.0/libraries/cluster-status",
+                    headers=self._headers,
+                    params={"cluster_id": cluster_id},
+                    timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
+                )
+                response.raise_for_status()
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                logger.warning(
+                    f"Transient network error polling library status on cluster {cluster_id}: {exc}. "
+                    f"Retrying in {Config.DATABRICKS_POLL_INTERVAL_SECONDS}s."
+                )
+                time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+                continue
+            data = response.json()
+            statuses = data.get("library_statuses", [])
+            if not statuses:
+                logger.info(
+                    f"Cluster {cluster_id}: no library statuses reported yet. Waiting."
+                )
+                time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+                continue
+
+            summary = ", ".join(
+                f"{self._library_label(s.get('library', {}))}={s.get('status', '')}"
+                for s in statuses
+            )
+            logger.info(f"Cluster {cluster_id} library status: {summary}")
+
+            failed = [
+                s
+                for s in statuses
+                if s.get("status", "") in DatabricksLibraryStatus.terminal_failure_values()
+            ]
+            if failed:
+                details = "; ".join(
+                    f"{self._library_label(s.get('library', {}))} -> {s.get('status', '')} "
+                    f"({s.get('messages', [])})"
+                    for s in failed
+                )
+                raise RuntimeError(
+                    f"One or more libraries failed to install on cluster {cluster_id}: {details}"
+                )
+
+            if all(
+                s.get("status", "") == DatabricksLibraryStatus.INSTALLED.value
+                for s in statuses
+            ):
+                return
+
+            time.sleep(Config.DATABRICKS_POLL_INTERVAL_SECONDS)
+
+    @staticmethod
+    def _library_label(library: dict) -> str:
+        if "maven" in library:
+            return library["maven"].get("coordinates", "maven:?")
+        if "pypi" in library:
+            return library["pypi"].get("package", "pypi:?")
+        return next(iter(library.keys()), "library")
 
     def _upload_notebook(self) -> None:
         folder = str(Path(Config.DATABRICKS_WORKSPACE_NOTEBOOK_PATH).parent)
@@ -51,7 +275,7 @@ class DatabricksService(IDatabricksService):
             f"{self._host}/api/2.0/workspace/mkdirs",
             headers=self._headers,
             json={"path": folder},
-            timeout=30,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
         )
         if not mkdirs_response.ok:
             raise RuntimeError(
@@ -71,7 +295,7 @@ class DatabricksService(IDatabricksService):
                 "content": content,
                 "overwrite": True,
             },
-            timeout=30,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
         )
         if not response.ok:
             raise RuntimeError(
@@ -81,9 +305,11 @@ class DatabricksService(IDatabricksService):
             f"Uploaded notebook to '{Config.DATABRICKS_WORKSPACE_NOTEBOOK_PATH}'."
         )
 
-    def _submit_run(self, num_workers: int) -> str:
+    def _submit_run(
+        self, cluster_id: str, num_workers: int, dataset_size: DatasetSize
+    ) -> str:
         payload = {
-            "run_name": f"national-scale-spatial-join-{num_workers}-nodes",
+            "run_name": f"national-scale-spatial-join-{num_workers}-nodes-{dataset_size.value}",
             "tasks": [
                 {
                     "task_key": "spatial-join",
@@ -94,26 +320,10 @@ class DatabricksService(IDatabricksService):
                             "account_name": Config.AZURE_BLOB_STORAGE_ACCOUNT_NAME,
                             "release": Config.BENCHMARK_DOPPA_DATA_RELEASE,
                             "municipalities_file": Config.DATABRICKS_MUNICIPALITIES_FILE,
+                            "dataset_size": dataset_size.value,
                         },
                     },
-                    "new_cluster": {
-                        "spark_version": Config.DATABRICKS_SPARK_VERSION,
-                        "node_type_id": Config.DATABRICKS_NODE_TYPE_ID,
-                        "num_workers": num_workers,
-                        "spark_conf": {
-                            "spark.driver.memory": Config.DATABRICKS_DRIVER_MEMORY,
-                            "spark.driver.memoryOverhead": Config.DATABRICKS_DRIVER_MEMORY_OVERHEAD,
-                        },
-                    },
-                    "libraries": [
-                        {
-                            "maven": {
-                                "coordinates": Config.DATABRICKS_SEDONA_MAVEN_COORDINATES
-                            }
-                        },
-                        {"pypi": {"package": Config.DATABRICKS_SEDONA_PYPI_PACKAGE}},
-                        {"pypi": {"package": "geopandas==0.14.4"}},
-                    ],
+                    "existing_cluster_id": cluster_id,
                 }
             ],
         }
@@ -122,7 +332,7 @@ class DatabricksService(IDatabricksService):
             f"{self._host}/api/2.1/jobs/runs/submit",
             headers=self._headers,
             json=payload,
-            timeout=30,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
         )
         if not response.ok:
             raise RuntimeError(
@@ -144,7 +354,7 @@ class DatabricksService(IDatabricksService):
                     f"{self._host}/api/2.1/jobs/runs/get",
                     headers=self._headers,
                     params={"run_id": run_id},
-                    timeout=30,
+                    timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
                 )
                 response.raise_for_status()
             except (requests.ConnectionError, requests.Timeout) as exc:
@@ -165,8 +375,8 @@ class DatabricksService(IDatabricksService):
                 state_msg += f", result_state={result_state}"
             logger.info(f"Run {run_id}: {state_msg}")
 
-            if life_cycle_state in _TERMINAL_STATES:
-                if result_state != "SUCCESS":
+            if life_cycle_state in DatabricksRunLifecycleState.terminal_values():
+                if result_state != DatabricksRunResultState.SUCCESS.value:
                     raise RuntimeError(
                         f"Databricks run {run_id} finished with result_state='{result_state}'. "
                         f"State message: {state.get('state_message', '')}"
@@ -204,7 +414,7 @@ class DatabricksService(IDatabricksService):
             f"{self._host}/api/2.1/jobs/runs/get-output",
             headers=self._headers,
             params={"run_id": run_id},
-            timeout=30,
+            timeout=Config.DATABRICKS_HTTP_TIMEOUT_SECONDS,
         )
         if not response.ok:
             raise RuntimeError(

--- a/src/infra/infrastructure/services/databricks_service.py
+++ b/src/infra/infrastructure/services/databricks_service.py
@@ -133,8 +133,9 @@ class DatabricksService(IDatabricksService):
         """Resolve the identity attached to the Databricks PAT.
 
         Workspaces that enforce Unity Catalog reject /clusters/create requests without an
-        explicit ``data_security_mode``. ``SINGLE_USER`` mode requires ``single_user_name``,
-        which must match the caller's identity, so we look it up from SCIM ``/Me``.
+        explicit ``data_security_mode``. Both ``SINGLE_USER`` and ``LEGACY_SINGLE_USER``
+        (the mode used here) require ``single_user_name`` to match the caller's identity,
+        so we look it up from SCIM ``/Me``.
         """
         response = requests.get(
             f"{self._host}/api/2.0/preview/scim/v2/Me",

--- a/src/presentation/databricks/national_scale_spatial_join.py
+++ b/src/presentation/databricks/national_scale_spatial_join.py
@@ -34,6 +34,7 @@ account_key = dbutils.widgets.get("account_key")
 account_name = dbutils.widgets.get("account_name")
 release = dbutils.widgets.get("release")
 municipalities_file = dbutils.widgets.get("municipalities_file")
+dataset_size = dbutils.widgets.get("dataset_size")
 
 # COMMAND ----------
 
@@ -48,7 +49,7 @@ sedona = SedonaContext.create(spark)
 
 buildings_path = (
     f"abfss://data@{account_name}.dfs.core.windows.net"
-    f"/release/{release}/theme=buildings/region=*/*.parquet"
+    f"/release/{release}/size={dataset_size}/theme=buildings/region=*/*.parquet"
 )
 municipalities_path = (
     f"abfss://metadata@{account_name}.dfs.core.windows.net"

--- a/src/presentation/entrypoints/_databricks_benchmark_runner.py
+++ b/src/presentation/entrypoints/_databricks_benchmark_runner.py
@@ -1,0 +1,63 @@
+from src.application.common.monitor import monitor
+from src.application.contracts import IDatabricksService
+from src.application.dtos import CostConfiguration, DatabricksRunResult
+from src.domain.enums import BenchmarkIteration, DatasetSize
+
+
+def run_databricks_national_scale_spatial_join(
+    databricks_service: IDatabricksService,
+    num_workers: int,
+    dataset_size: DatasetSize,
+) -> None:
+    """
+    Provision a Databricks cluster once, run the national-scale spatial join benchmark
+    (warmup + timed iterations) against it for the given dataset size, then terminate the
+    cluster.
+
+    Cluster provisioning happens outside the ``@monitor`` timing window so reported elapsed
+    time and reported cost both cover the same span: warmup + timed iterations on a warm
+    engine. ``query_id`` encodes ``num_workers`` and (when not ``SMALL``) ``dataset_size``
+    so results are keyed unambiguously without renaming existing small-dataset rows.
+    """
+    cluster_id = databricks_service.create_cluster(num_workers=num_workers)
+    try:
+        benchmark_fn = _build_benchmark_fn(
+            num_workers=num_workers, dataset_size=dataset_size
+        )
+        benchmark_fn(
+            cluster_id=cluster_id,
+            num_workers=num_workers,
+            dataset_size=dataset_size,
+            databricks_service=databricks_service,
+        )
+    finally:
+        databricks_service.terminate_cluster(cluster_id=cluster_id)
+
+
+def _build_benchmark_fn(num_workers: int, dataset_size: DatasetSize):
+    query_id = f"national-scale-spatial-join-databricks-{num_workers}-nodes"
+    if dataset_size is not DatasetSize.SMALL:
+        query_id += f"-{dataset_size.value}"
+
+    @monitor(
+        query_id=query_id,
+        benchmark_iteration=BenchmarkIteration.NATIONAL_SCALE_SPATIAL_JOIN,
+        cost_configuration=CostConfiguration(
+            include_aci=True, include_databricks=True, num_workers=num_workers
+        ),
+        skip_warmup=False,
+        elapsed_from_result=True,
+    )
+    def _benchmark(
+        cluster_id: str,
+        num_workers: int,
+        dataset_size: DatasetSize,
+        databricks_service: IDatabricksService,
+    ) -> DatabricksRunResult:
+        return databricks_service.submit_to_existing_cluster(
+            cluster_id=cluster_id,
+            num_workers=num_workers,
+            dataset_size=dataset_size,
+        )
+
+    return _benchmark

--- a/src/presentation/entrypoints/_databricks_benchmark_runner.py
+++ b/src/presentation/entrypoints/_databricks_benchmark_runner.py
@@ -14,10 +14,12 @@ def run_databricks_national_scale_spatial_join(
     (warmup + timed iterations) against it for the given dataset size, then terminate the
     cluster.
 
-    Cluster provisioning happens outside the ``@monitor`` timing window so reported elapsed
-    time and reported cost both cover the same span: warmup + timed iterations on a warm
-    engine. ``query_id`` encodes ``num_workers`` and (when not ``SMALL``) ``dataset_size``
-    so results are keyed unambiguously without renaming existing small-dataset rows.
+    Cluster provisioning happens outside the ``@monitor`` timing window. Warmup runs
+    execute on the same cluster but before ``@monitor`` opens its cost window, so both
+    reported elapsed time and reported cost cover the timed iterations only, on an
+    already-warm engine. ``query_id`` encodes ``num_workers`` and (when not ``SMALL``)
+    ``dataset_size`` so results are keyed unambiguously without renaming existing
+    small-dataset rows.
     """
     cluster_id = databricks_service.create_cluster(num_workers=num_workers)
     try:

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_2_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_2_nodes.py
@@ -1,33 +1,26 @@
 from dependency_injector.wiring import Provide, inject
 
-from src.application.common.monitor import monitor
 from src.application.contracts import IDatabricksService
-from src.application.dtos import CostConfiguration, DatabricksRunResult
-from src.domain.enums import BenchmarkIteration
+from src.domain.enums import DatasetSize
 from src.infra.infrastructure import Containers
+from src.presentation.entrypoints._databricks_benchmark_runner import (
+    run_databricks_national_scale_spatial_join,
+)
 
 
 @inject
 def national_scale_spatial_join_databricks_2_nodes(
+    dataset_size: DatasetSize = DatasetSize.SMALL,
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
 ) -> None:
     """
-    Benchmark: national-scale spatial join between Norwegian counties and the small
-    buildings dataset executed on Azure Databricks with a 2-worker cluster. Submits
-    the Databricks notebook job and waits for completion.
+    Benchmark: national-scale spatial join between Norwegian counties and the configured
+    buildings dataset size executed on Azure Databricks with a 2-worker cluster. The
+    cluster is provisioned once, every warmup and timed iteration runs against it, and the
+    cluster is terminated after the benchmark completes.
     """
-    _benchmark(databricks_service=databricks_service)
-
-
-@inject
-@monitor(
-    query_id="national-scale-spatial-join-databricks-2-nodes",
-    benchmark_iteration=BenchmarkIteration.NATIONAL_SCALE_SPATIAL_JOIN,
-    cost_configuration=CostConfiguration(include_aci=True, include_databricks=True, num_workers=2),
-    skip_warmup=True,
-    elapsed_from_result=True,
-)
-def _benchmark(
-    databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> DatabricksRunResult:
-    return databricks_service.submit_and_wait(num_workers=2)
+    run_databricks_national_scale_spatial_join(
+        databricks_service=databricks_service,
+        num_workers=2,
+        dataset_size=dataset_size,
+    )

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_4_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_4_nodes.py
@@ -1,33 +1,26 @@
 from dependency_injector.wiring import Provide, inject
 
-from src.application.common.monitor import monitor
 from src.application.contracts import IDatabricksService
-from src.application.dtos import CostConfiguration, DatabricksRunResult
-from src.domain.enums import BenchmarkIteration
+from src.domain.enums import DatasetSize
 from src.infra.infrastructure import Containers
+from src.presentation.entrypoints._databricks_benchmark_runner import (
+    run_databricks_national_scale_spatial_join,
+)
 
 
 @inject
 def national_scale_spatial_join_databricks_4_nodes(
+    dataset_size: DatasetSize = DatasetSize.SMALL,
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
 ) -> None:
     """
-    Benchmark: national-scale spatial join between Norwegian counties and the small
-    buildings dataset executed on Azure Databricks with a 4-worker cluster. Submits
-    the Databricks notebook job and waits for completion.
+    Benchmark: national-scale spatial join between Norwegian counties and the configured
+    buildings dataset size executed on Azure Databricks with a 4-worker cluster. The
+    cluster is provisioned once, every warmup and timed iteration runs against it, and the
+    cluster is terminated after the benchmark completes.
     """
-    _benchmark(databricks_service=databricks_service)
-
-
-@inject
-@monitor(
-    query_id="national-scale-spatial-join-databricks-4-nodes",
-    benchmark_iteration=BenchmarkIteration.NATIONAL_SCALE_SPATIAL_JOIN,
-    cost_configuration=CostConfiguration(include_aci=True, include_databricks=True, num_workers=4),
-    skip_warmup=True,
-    elapsed_from_result=True,
-)
-def _benchmark(
-    databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> DatabricksRunResult:
-    return databricks_service.submit_and_wait(num_workers=4)
+    run_databricks_national_scale_spatial_join(
+        databricks_service=databricks_service,
+        num_workers=4,
+        dataset_size=dataset_size,
+    )

--- a/src/presentation/entrypoints/national_scale_spatial_join_databricks_8_nodes.py
+++ b/src/presentation/entrypoints/national_scale_spatial_join_databricks_8_nodes.py
@@ -1,33 +1,26 @@
 from dependency_injector.wiring import Provide, inject
 
-from src.application.common.monitor import monitor
 from src.application.contracts import IDatabricksService
-from src.application.dtos import CostConfiguration, DatabricksRunResult
-from src.domain.enums import BenchmarkIteration
+from src.domain.enums import DatasetSize
 from src.infra.infrastructure import Containers
+from src.presentation.entrypoints._databricks_benchmark_runner import (
+    run_databricks_national_scale_spatial_join,
+)
 
 
 @inject
 def national_scale_spatial_join_databricks_8_nodes(
+    dataset_size: DatasetSize = DatasetSize.SMALL,
     databricks_service: IDatabricksService = Provide[Containers.databricks_service],
 ) -> None:
     """
-    Benchmark: national-scale spatial join between Norwegian counties and the small
-    buildings dataset executed on Azure Databricks with an 8-worker cluster. Submits
-    the Databricks notebook job and waits for completion.
+    Benchmark: national-scale spatial join between Norwegian counties and the configured
+    buildings dataset size executed on Azure Databricks with an 8-worker cluster. The
+    cluster is provisioned once, every warmup and timed iteration runs against it, and the
+    cluster is terminated after the benchmark completes.
     """
-    _benchmark(databricks_service=databricks_service)
-
-
-@inject
-@monitor(
-    query_id="national-scale-spatial-join-databricks-8-nodes",
-    benchmark_iteration=BenchmarkIteration.NATIONAL_SCALE_SPATIAL_JOIN,
-    cost_configuration=CostConfiguration(include_aci=True, include_databricks=True, num_workers=8),
-    skip_warmup=True,
-    elapsed_from_result=True,
-)
-def _benchmark(
-    databricks_service: IDatabricksService = Provide[Containers.databricks_service],
-) -> DatabricksRunResult:
-    return databricks_service.submit_and_wait(num_workers=8)
+    run_databricks_national_scale_spatial_join(
+        databricks_service=databricks_service,
+        num_workers=8,
+        dataset_size=dataset_size,
+    )


### PR DESCRIPTION
This pull request introduces significant improvements to the Databricks benchmarking workflow, refactoring how clusters are managed and jobs are submitted, and making the system more robust and configurable. The main changes include splitting cluster lifecycle management into separate methods, supporting dataset size selection, and enhancing error handling and logging. Additionally, new enums were introduced for better state management, and configuration options were updated.

**Databricks Cluster Lifecycle Refactor and Dataset Size Support**

*Major refactoring and new features:*

- The Databricks service now separates cluster creation, job submission, and cluster termination into individual methods (`create_cluster`, `submit_to_existing_cluster`, and `terminate_cluster`), improving modularity and error handling. (`[[1]](diffhunk://#diff-14119b5b2629edaab0d490f65545d6217d73cc8d299e959af74776cb1324cb07R4-R53)`, `[[2]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L39-R278)`)
- The job submission logic now supports specifying the dataset size (via the new `DatasetSize` enum), making benchmarks more flexible. (`[[1]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8L141-R154)`, `[[2]](diffhunk://#diff-14119b5b2629edaab0d490f65545d6217d73cc8d299e959af74776cb1324cb07R4-R53)`, `[[3]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L12-R18)`, `[[4]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L39-R278)`, `[[5]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L84-R312)`, `[[6]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11R323-R326)`)

**Robustness and State Management Enhancements**

- Introduced new enums for Databricks cluster state, library status, and run state, improving clarity and safety when handling API responses. (`[[1]](diffhunk://#diff-f67e0ea3db24648f04d7ce3f43496c85e29ab512e6ef89131891d23f4928c842R5-R7)`, `[[2]](diffhunk://#diff-0374fdeeeac267ef546d21fddd24812e1b3e154f900287642eae8c46084cb49dR1-R23)`, `[[3]](diffhunk://#diff-815a623c8e0e04e2f1c7933f1f41b14a03bd6f0fa5c2b5f3c4c46de75dc26f73R1-R17)`, `[[4]](diffhunk://#diff-6d10191292eabcee84b26fe510da991d7b2d44fc5a3d7a1b4c01e0b16cfe2cd1R1-R25)`)
- Improved error handling throughout the Databricks service: clusters are terminated on provisioning failure, and robust polling with logging is implemented for cluster and library readiness. (`[src/infra/infrastructure/services/databricks_service.pyL39-R278](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L39-R278)`)

**Configuration Updates**

- Added new configuration options, including `DATABRICKS_HTTP_TIMEOUT_SECONDS` and `DATABRICKS_GEOPANDAS_PYPI_PACKAGE`, and updated the default data release version. (`[[1]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592L110-R110)`, `[[2]](diffhunk://#diff-24a3fe5c783755412cb9de83238b4dfd0699345bf50dcadc3ec23c6749361592R124-R131)`)
- All HTTP requests in the Databricks service now use the configurable timeout. (`[[1]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L74-R298)`, `[[2]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L84-R312)`)

**Code Integration and Imports**

- Updated imports across modules to reflect the new enums and configuration options. (`[[1]](diffhunk://#diff-56f497f357c1a86b3152b78bc93c915029e06e2021f9a1b2ca20caf80a1823d8R3)`, `[[2]](diffhunk://#diff-b315a4aa8efe57fd11372255ac1e19c14bdcb8e6a6ebebfb86e4cc79fae75d11L12-R18)`)

Overall, these changes make the Databricks benchmarking pipeline more maintainable, configurable, and robust against failures.