### PR TITLE
Feature/266 bump clone multipliers to hit 40m100m dataset targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Files are written as GeoParquet 1.1.0 with:
 | Size     | Target row count | Source                                                                                                  |
 |----------|------------------|---------------------------------------------------------------------------------------------------------|
 | `small`  | ~5M              | Conflation of OSM + FKB. Written directly by `TestDatasetService` during setup.                         |
-| `medium` | ~40M             | `DatasetSynthesisService`: 7 clones per source polygon (translate + rotate + jitter, drop invalid).     |
-| `large`  | ~100M            | `DatasetSynthesisService`: 19 clones per source polygon.                                                |
+| `medium` | ~40M             | `DatasetSynthesisService`: 9 clones per source polygon (translate + rotate + jitter, drop invalid).     |
+| `large`  | ~100M            | `DatasetSynthesisService`: 23 clones per source polygon.                                                |
 
-Per-polygon clone counts are exposed on the enum (`DatasetSize.MEDIUM.clones_per_polygon == 7`). Synthetic clones
+Per-polygon clone counts are exposed on the enum (`DatasetSize.MEDIUM.clones_per_polygon == 9`). Synthetic clones
 carry the same schema as originals, with non-geometry attributes (e.g. `building_type`, `building_id`, `source`)
 left `NULL`. The `partition_key` is recomputed for clones from the new centroid.
 
@@ -507,8 +507,8 @@ A full `setup_benchmarking_framework` run on real Azure resources is dominated b
 | Step | Description                              | Approximate runtime |
 |------|------------------------------------------|---------------------|
 | 1    | `test_dataset_service.run_pipeline()`    | 25–55 min           |
-| 2    | Synthesize medium (~40M rows)            | 25–40 min           |
-| 3    | Synthesize large (~100M rows)            | 50–90 min           |
+| 2    | Synthesize medium (~40M rows)            | 30–50 min           |
+| 3    | Synthesize large (~100M rows)            | 60–110 min          |
 | 4    | Postgres seed (small + medium + large)   | 3.5–7 hr            |
 | 5    | Shapefile copy                           | 3–5 min             |
 

--- a/src/domain/enums/dataset_size.py
+++ b/src/domain/enums/dataset_size.py
@@ -10,13 +10,13 @@ class DatasetSize(Enum):
     def clones_per_polygon(self) -> int:
         """
         Number of synthetic clones generated per source polygon when synthesizing this dataset size.
-        `SMALL` is a passthrough (no clones), `MEDIUM` produces 7 clones per source polygon (target ~40M total),
-        and `LARGE` produces 19 clones per source polygon (target ~100M total).
+        `SMALL` is a passthrough (no clones), `MEDIUM` produces 9 clones per source polygon (target ~40M total),
+        and `LARGE` produces 23 clones per source polygon (target ~100M total).
         """
         match self:
             case DatasetSize.SMALL:
                 return 0
             case DatasetSize.MEDIUM:
-                return 7
+                return 9
             case DatasetSize.LARGE:
-                return 19
+                return 23


### PR DESCRIPTION
This pull request updates the synthetic dataset generation process to increase the number of clones per source polygon for both the `MEDIUM` and `LARGE` dataset sizes. The documentation and code have been updated to reflect these new clone counts, and the expected runtimes for dataset synthesis have been adjusted accordingly.

**Dataset synthesis changes:**

* Increased the number of synthetic clones per source polygon for `DatasetSize.MEDIUM` from 7 to 9 and for `DatasetSize.LARGE` from 19 to 23 in the `DatasetSize` enum (`src/domain/enums/dataset_size.py`).
* Updated the documentation in `README.md` to reflect the new clone counts for `medium` and `large` dataset sizes, including the code examples and explanatory text.

**Benchmarking/runtime documentation:**

* Adjusted the documented expected runtimes for synthesizing medium and large datasets in `README.md` to account for the increased number of clones (medium: 30–50 min, large: 60–110 min).